### PR TITLE
Add read:org permissions to github auth

### DIFF
--- a/templates/dockstore.model.ts.template
+++ b/templates/dockstore.model.ts.template
@@ -12,7 +12,7 @@ export class Dockstore {
   static readonly GITHUB_CLIENT_ID = '{{ GITHUB_CLIENT2_ID }}';
   static readonly GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
   static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/github.com';
-  static readonly GITHUB_SCOPE = 'user,user:email';
+  static readonly GITHUB_SCOPE = 'read:org,user,user:email';
 
   static readonly QUAYIO_AUTH_URL = 'https://quay.io/oauth/authorize';
   static readonly QUAYIO_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/quay';


### PR DESCRIPTION
Read:org permissions are needed for workflow refresh all functionality.