### PR TITLE
Use provider enum

### DIFF
--- a/templates/dockstore.model.ts.template
+++ b/templates/dockstore.model.ts.template
@@ -1,3 +1,4 @@
+import { Provider } from './enum/provider.enum';
 export class Dockstore {
 
   // Please fill in HOSTNAME with your address
@@ -11,11 +12,11 @@ export class Dockstore {
 
   static readonly GITHUB_CLIENT_ID = '{{ GITHUB_CLIENT2_ID }}';
   static readonly GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
-  static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/github.com';
+  static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITHUB;
   static readonly GITHUB_SCOPE = 'read:org,user,user:email';
 
   static readonly QUAYIO_AUTH_URL = 'https://quay.io/oauth/authorize';
-  static readonly QUAYIO_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/quay';
+  static readonly QUAYIO_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.QUAY;
   static readonly QUAYIO_SCOPE = 'repo:read,user:read';
   static readonly QUAYIO_CLIENT_ID = '{{ QUAY_CLIENT_ID }}';
 
@@ -24,6 +25,6 @@ export class Dockstore {
 
   static readonly GITLAB_AUTH_URL = 'https://gitlab.com/oauth/authorize';
   static readonly GITLAB_CLIENT_ID = '{{ GITLAB_CLIENT_ID }}';
-  static readonly GITLAB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/gitlab';
+  static readonly GITLAB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITLAB;
 }
 


### PR DESCRIPTION
Simple change to the dockstore.model.ts.  The default Provider.enums were changed to match UI1's.  Change the third party integration to match UI1's.  See the primer for details.