### PR TITLE
Upgrade node

### DIFF
--- a/templates/Dockerfile_ui2.template
+++ b/templates/Dockerfile_ui2.template
@@ -10,18 +10,17 @@ RUN apt-get update \
     && apt-get clean
 
 #prerequisities
-RUN curl -sL https://deb.nodesource.com/setup_7.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g @angular/cli@1.3.1
+RUN npm install -g @angular/cli@1.3.1 --unsafe
 #npm
 RUN git clone https://github.com/dockstore/dockstore-ui2.git
 WORKDIR /dockstore-ui2
 RUN git checkout {{ DOCKSTORE_UI2_VERSION }}
 
 RUN npm install --production
-RUN wget https://artifacts.oicr.on.ca/artifactory/collab-release/io/swagger/swagger-codegen-cli/2.3.0-SNAPSHOT/swagger-codegen-cli-2.3.0-20170927.194112-1.jar -O swagger-codegen-cli.jar
+RUN wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O swagger-codegen-cli.jar
 RUN java -jar swagger-codegen-cli.jar generate -i https://raw.githubusercontent.com/ga4gh/dockstore/{{ DOCKSTORE_VERSION  }}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
-RUN bash script.sh
 RUN npm run-script prebuild
 
 ADD config/{{ GOOGLE_VERIFICATION_NAME }}.html {{ GOOGLE_VERIFICATION_NAME }}.html

--- a/templates/dockstore.model.ts.template
+++ b/templates/dockstore.model.ts.template
@@ -13,6 +13,8 @@ export class Dockstore {
   static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT;
   static readonly DNASTACK_IMPORT_URL= 'https://app.dnastack.com/#/app/workflow/import/dockstore';
 
+  static readonly GOOGLE_SHORTENER_KEY = 'fill_this_in';
+
   static readonly GITHUB_CLIENT_ID = '{{ GITHUB_CLIENT2_ID }}';
   static readonly GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
   static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITHUB;


### PR DESCRIPTION
This for the npm 5 upgrade.  It also updates swagger codegen and has a temporary google shortener key workaround that should be updated in another pull request.