### PR TITLE
Remove user from github scope

### DIFF
--- a/templates/dockstore.model.ts.template
+++ b/templates/dockstore.model.ts.template
@@ -16,7 +16,7 @@ export class Dockstore {
   static readonly GITHUB_CLIENT_ID = '{{ GITHUB_CLIENT2_ID }}';
   static readonly GITHUB_AUTH_URL = 'https://github.com/login/oauth/authorize';
   static readonly GITHUB_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.GITHUB;
-  static readonly GITHUB_SCOPE = 'read:org,user,user:email';
+  static readonly GITHUB_SCOPE = 'read:org,user:email';
 
   static readonly QUAYIO_AUTH_URL = 'https://quay.io/oauth/authorize';
   static readonly QUAYIO_REDIRECT_URI = Dockstore.LOCAL_URI + '/auth/' + Provider.QUAY;


### PR DESCRIPTION
For issue ga4gh/dockstore#1126 Remove user from GitHub scope. On a fresh database, GitHub account info gets automatically synced upon first visit. New workflows/tools are automatically added via refresh all.