### PR TITLE
Feature/move logstash

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The bootstrap script can also rebuild your Docker images and spin them up althou
     2. `docker-compose up --force-recreate --remove-orphans` will re-create all containers known to docker-compose and delete those volumes that no longer are associated with running containers
     3. `docker system prune` for cleaning out old containers and images
 
-If using with logstash, use `-f docker-compose.yml -f docker-compose.dev.yml` flags after each `docker-compose` command to merge docker-compose files
+If using with logstash, use `-f docker-compose.yml -f docker-compose.dev.yml` flags after each `docker-compose` command to merge docker-compose files (e.g. `docker-compose -f docker-compse.yml -f docker-compose.dev.yml build`) 
 
 3. After following the instructions in the bootstrap script and either letting it rebuild the Docker containers and running them on your own, you can browse to the Dockstore site hosted at port 443 by default. `https://<domain-name>` if you specified https or `http://<domain-name>:443` if you did not. 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,23 @@
 version: '2'
 services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.3
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+    volumes:
+      - esdata1:/usr/share/elasticsearch/data
+    expose:
+      - "9200"
+      - "9300"
+    volumes:
+      - ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
   logstash:
     image: docker.elastic.co/logstash/logstash-oss:6.1.3
     restart: always
@@ -7,6 +25,12 @@ services:
       - elasticsearch
     volumes:
       - ./config/logsToElastic.conf:/usr/share/logstash/pipeline/logsToElastic.conf
-    expose:
-      - "5055" 
+    ports:
+      - "5055:5055"
+  kibana:
+    image: docker.elastic.co/kibana/kibana:5.6.3
+    ports:
+     - "5601:5601"
+    depends_on:
+     - elasticsearch
 


### PR DESCRIPTION
Adds an example on how to merge docker-compose files.

Adds elasticsearch and kibana to the dev docker-compose file so that it can run entirely independant of the other docker-compose file.  There does not appear to be any obvious issues with merge build/up both files even though both of them have elasticsearch defined