### PR TITLE
Feature/logstash latency

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.6.3
+    restart: always
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
@@ -29,6 +30,7 @@ services:
       - "5055:5055"
   kibana:
     image: docker.elastic.co/kibana/kibana:5.6.3
+    restart: always
     ports:
      - "5601:5601"
     depends_on:

--- a/templates/logsToElastic.conf
+++ b/templates/logsToElastic.conf
@@ -15,7 +15,7 @@ input {
 
 filter {
   grok {
-    match => { "message" => "%{COMBINEDAPACHELOG}" }
+    match => { "message" => "%{COMBINEDAPACHELOG} %{POSINT:latency}" }
   }
   date {
     match => [ "timestamp" , "dd/MMM/yyyy:HH:mm:ss Z" ]


### PR DESCRIPTION
- Always restart elasticsearch and kibana
- Add latency to the logstash
- Apparently, kibana dashboard is saved in elasticsearch and that's already retained, no changes needed for that.