### PR TITLE
Convert latency to number

### DIFF
--- a/templates/logsToElastic.conf
+++ b/templates/logsToElastic.conf
@@ -15,7 +15,7 @@ input {
 
 filter {
   grok {
-    match => { "message" => "%{COMBINEDAPACHELOG} %{POSINT:latency}" }
+    match => { "message" => "%{COMBINEDAPACHELOG} %{NUMBER:latency:int}" }
   }
   date {
     match => [ "timestamp" , "dd/MMM/yyyy:HH:mm:ss Z" ]


### PR DESCRIPTION
Simply converting the logash latency field from a string to a number