### PR TITLE
Update cli version for Angular 6

### DIFF
--- a/dockstore_launcher_config/compose.config
+++ b/dockstore_launcher_config/compose.config
@@ -17,6 +17,8 @@
 "TAG_MANAGER_ID":"foobar",
 "GITLAB_CLIENT_ID":"foobar",
 "GITLAB_CLIENT_SECRET":"foobar",
+"GOOGLE_CLIENT_ID":"potato",
+"GOOGLE_CLIENT_SECRET":"potato",
 "LOGSTASH":false,
 "ENABLE_CWL_VIEWER":"false",
 "ENABLE_LAUNCH_WITH_FIRECLOUD":"false",

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -36,6 +36,8 @@ GOOGLE_VERIFICATION_NAME=''
 TAG_MANAGER_ID=''
 GITLAB_CLIENT_ID=''
 GITLAB_CLIENT_SECRET=''
+GOOGLE_CLIENT_ID=''
+GOOGLE_CLIENT_SECRET=''
 LOGSTASH=''
 ENABLE_CWL_VIEWER=''
 ENABLE_LAUNCH_WITH_FIRECLOUD=''
@@ -211,6 +213,11 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
         gitlab_client_secret='gitlab_client_secret'
         ask_question "What is your gitlab client secret?" "$GITLAB_CLIENT_SECRET" "Dockstore version" $gitlab_client_secret
 
+        google_client_id='google_client_id'
+        ask_question "What is your google client id?" "$GOOGLE_CLIENT_ID" "Dockstore version" $google_client_id
+        google_client_secret='google_client_secret'
+        ask_question "What is your google client secret?" "$GOOGLE_CLIENT_SECRET" "Dockstore version" $google_client_secret
+
         domain_name='domain_name'
         ask_question "What is the domain name for this server (can be an ip address for development)?" "$DOMAIN_NAME" "Domain name" $domain_name
         https='https'
@@ -262,6 +269,8 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
 "TAG_MANAGER_ID":"${tag_manager_id}",
 "GITLAB_CLIENT_ID":"${gitlab_client_id}",
 "GITLAB_CLIENT_SECRET":"${gitlab_client_secret}",
+"GOOGLE_CLIENT_ID":"${google_client_id}",
+"GOOGLE_CLIENT_SECRET":"${google_client_secret}",
 "LOGSTASH":${logstash},
 "ENABLE_CWL_VIEWER":"${enable_cwl_viewer}",
 "ENABLE_LAUNCH_WITH_FIRECLOUD":"${enable_launch_with_firecloud}",

--- a/templates/Dockerfile_ui2.template
+++ b/templates/Dockerfile_ui2.template
@@ -12,7 +12,7 @@ RUN apt-get update \
 #prerequisities
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g @angular/cli@1.3.1 --unsafe
+RUN npm install -g @angular/cli@6.0.2 --unsafe
 #npm
 RUN touch {{ DOCKSTORE_UI2_VERSION }}.out
 RUN git clone https://github.com/dockstore/dockstore-ui2.git

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -17,6 +17,10 @@ gitlabClientID: {{ GITLAB_CLIENT_ID }}
 gitlabClientSecret: {{ GITLAB_CLIENT_SECRET }}
 gitlabRedirectURI: http{{#HTTPS}}s{{/HTTPS}}://{{ DOMAIN_NAME }}:443/auth/gitlab.com
 
+googleClientID: {{ GOOGLE_CLIENT_ID }}
+googleClientSecret: {{ GOOGLE_CLIENT_SECRET }}
+googleRedirectURI: http{{#HTTPS}}s{{/HTTPS}}://{{ DOMAIN_NAME }}:443
+
 esconfiguration:
   port: 9200
   hostname: elasticsearch


### PR DESCRIPTION
Update CLI version to match Angular 6 upgrade.  Should work even with older Angular versions.  May want to just consider updating to latest instead since so far the local package.json's version is used instead with `ng` commands (but for some reason Angular/CLI needs to be installed globally still or else `ng` not found)

Also adding google oauth