### PR TITLE
Feature/run migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,7 @@ CREATE SCHEMA public;
 psql -f  /tmp/backup.sql 
 ```
 
-### Database Migrations ###
-You can run database migrations using Dropwizard. First make sure that the webservice is running. The following command can be used to run migrations. Note that the context needs to be filled in.
-
-```
-docker-compose run webservice java -jar dockstore-webservice-<version number here>.jar db migrate web.yml --include <context>
-```
-
-To run migrations for 1.4.0, run the following command:
-
-```
-docker-compose run webservice java -jar dockstore-webservice-<version number here>.jar db migrate web.yml --include 1.4.0
-
-```
+Note that database migration is run once during the startup process and is controlled via the `DATABASE_GENERATED` variable. Answer `yes` if you are working as a developer and want to start work from scratch from an empty database. Answer `no` if you are working as an administrator and/or wish to start Dockstore from a production or staging copy of the database.
 
 ### Kibana Dashboard Setup ###
 Import the [export.json](export.json) Dashboard from compose\_setup/export.json by going to Kibana's management => saved objects => import.  See https://www.elastic.co/guide/en/kibana/current/managing-saved-objects.html for more info, especially the 2nd warning.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   postgres:
-    image: postgres:9.6
+    image: postgres:9.6.10
     restart: always
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
@@ -29,6 +29,17 @@ services:
     volumes:
       - ./config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
 
+  migration: 
+    build:
+      context: .
+      dockerfile: config/Dockerfile_webservice
+    depends_on:
+      - postgres
+    volumes:
+      - log_volume:/dockstore_logs
+      - ./config/web.yml:/web.yml
+    command: ["dockerize", "-wait", "tcp://postgres:5432", "-timeout", "60s", "./init_migration.sh"]
+
   webservice: 
     build:
       context: .
@@ -37,6 +48,7 @@ services:
     depends_on:
       - postgres
       - elasticsearch
+      - migration
     volumes:
       - log_volume:/dockstore_logs
       - ./config/web.yml:/web.yml

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -45,6 +45,7 @@ GOOGLE_VERIFICATION_NAME=''
 AUTHORIZER_TYPE=''
 EXTERNAL_GOOGLE_CLIENT_PREFIX1=''
 SAM_PATH=''
+DATABASE_GENERATED=''
 
 function template()
 {
@@ -59,6 +60,7 @@ function template()
     mustache dockstore_launcher_config/compose.config templates/default.nginx_https.shared.conf.template > config/default.nginx_https.shared.conf
 
     mustache dockstore_launcher_config/compose.config templates/init_webservice.sh.template > config/init_webservice.sh
+    mustache dockstore_launcher_config/compose.config templates/init_migration.sh.template > config/init_migration.sh
     mustache dockstore_launcher_config/compose.config templates/init_ui2.sh.template > config/init_ui2.sh
     mustache dockstore_launcher_config/compose.config templates/elasticsearch.yml > config/elasticsearch.yml
     mustache dockstore_launcher_config/compose.config templates/search_verification.html > config/${GOOGLE_VERIFICATION_NAME}.html
@@ -252,6 +254,9 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
         sam_path='sam_path'
         ask_question "What is the path for the sam instance you wish to point at?" "$SAM_PATH" "sam_path" $sam_path
 
+        database_generated='database_generated'
+        ask_question "Do you want to run migration assuming a generated database as opposed to a production DB (true or false)?" "$DATABASE_GENERATED" "database_generated" $database_generated
+
         # Now write a config for this file.
         [[ -f dockstore_launcher_config/compose.config ]] || mkdir -p dockstore_launcher_config
                # Note: You can't have ANY blank lines in .dockstore/dockstore.config because the python library that will eventually process it does not like blank lines and will fail.
@@ -285,7 +290,8 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
 "FIRECLOUD_IMPORT_URL":"${firecloud_import_url}",
 "AUTHORIZER_TYPE":"${authorizer_type}",
 "EXTERNAL_GOOGLE_CLIENT_PREFIX1":"${external_google_client_prefix1}",
-"SAM_PATH":"${sam_path}"
+"SAM_PATH":"${sam_path}",
+"DATABASE_GENERATED":"${database_generated}"
 }
 CONFIG
     elif [ "${run_dockstore_launcher^^}" = 'N' ] ; then

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -291,7 +291,7 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
 "AUTHORIZER_TYPE":"${authorizer_type}",
 "EXTERNAL_GOOGLE_CLIENT_PREFIX1":"${external_google_client_prefix1}",
 "SAM_PATH":"${sam_path}",
-"DATABASE_GENERATED":"${database_generated}"
+"DATABASE_GENERATED":${database_generated}
 }
 CONFIG
     elif [ "${run_dockstore_launcher^^}" = 'N' ] ; then

--- a/templates/Dockerfile_webservice.template
+++ b/templates/Dockerfile_webservice.template
@@ -28,6 +28,7 @@ RUN wget --no-verbose https://github.com/jwilder/dockerize/releases/download/$DO
 
 # the web and Consonance config
 ADD config/init_webservice.sh .
+ADD config/init_migration.sh .
 
 RUN chmod u+x init_webservice.sh
 # TODO: make sure you create these from the .template files and customize them

--- a/templates/Dockerfile_webservice.template
+++ b/templates/Dockerfile_webservice.template
@@ -31,6 +31,7 @@ ADD config/init_webservice.sh .
 ADD config/init_migration.sh .
 
 RUN chmod u+x init_webservice.sh
+RUN chmod u+x init_migration.sh
 # TODO: make sure you create these from the .template files and customize them
 RUN mkdir /dockstore_logs && chmod a+rx /dockstore_logs
 

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+{{#DATABASE_GENERATED}}
+java -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0 | tee --append /dockstore_logs/webservice.out
+{{/DATABASE_GENERATED}}
+{{^DATABASE_GENERATED}}
+java -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0 | tee --append /dockstore_logs/webservice.out
+{{/DATABASE_GENERATED}}


### PR DESCRIPTION
Working on https://github.com/ga4gh/dockstore/issues/1656

Running migration as a one-off command seems to confuse compose which will make it stick around and restart. Explicitly running it as a part of docker compose like the ui2 build seems to fix the issue and streamline things since migration is idempotent anyway 