### PR TITLE
Better fallback when pattern not understood

### DIFF
--- a/templates/logsToElastic.conf
+++ b/templates/logsToElastic.conf
@@ -28,7 +28,7 @@ filter {
   translate {
     field => "path"
     destination => "generalizedPath"
-    fallback => path
+    fallback => "%{[path]}"
     dictionary => {
       "^/containers/path/[^/]+/tags$" => "/containers/path/{containerId}/tags"
       "^/containers/[^/]+/verify/[^/]+$" => "/containers/{containerId}/verify/{tagId}"


### PR DESCRIPTION
Pattern matching not extensive enough to cover all new endpoint paths automatically.
Adding a better fallback for now.