### PR TITLE
Install devDeps

### DIFF
--- a/templates/Dockerfile_ui2.template
+++ b/templates/Dockerfile_ui2.template
@@ -22,7 +22,7 @@ RUN git checkout {{ DOCKSTORE_UI2_VERSION }}
 COPY config/dockstore.model.ts /dockstore-ui2/src/app/shared/dockstore.model.ts
 COPY config/index.html /dockstore-ui2/src/index.html
 
-RUN npm install --production
+RUN npm install
 RUN wget http://central.maven.org/maven2/io/swagger/swagger-codegen-cli/2.3.1/swagger-codegen-cli-2.3.1.jar -O swagger-codegen-cli.jar
 RUN java -jar swagger-codegen-cli.jar generate -i https://raw.githubusercontent.com/ga4gh/dockstore/{{ DOCKSTORE_VERSION  }}/dockstore-webservice/src/main/resources/swagger.yaml -l typescript-angular -o src/app/shared/swagger -c swagger-config.json
 RUN npm run-script prebuild


### PR DESCRIPTION
Apparently building the production build is part of the dev process and thus requires devDeps.  
It currently works right now because alot of devDeps were historically moved to prod deps (should move them back at some point).