### PR TITLE
Feature/enhance snapshot backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config
 install_wget_curl.log
 dockstore_launcher_config
 essnapshot
+scripts/essnapshot_backup.sh

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -50,6 +50,8 @@ curl -X PUT "localhost:9200/_snapshot/my_backup" -H 'Content-Type: application/j
 ### Delete snapshot
 `curl -X DELETE "localhost:9200/_snapshot/my_backup/snapshot-2018.09.26"`
 
+Alternatively, you can delete old snapshots automatically using curator.  Install with `pip install elasticsearch-curator` then delete old with `curator --config curator.yml delete_old_snapshots.yml` inside the curator directory.
+
 
 ### Restoring snapshots
 - `curl -X POST "localhost:9200/_all/_close"` 

--- a/curator/curator.yml
+++ b/curator/curator.yml
@@ -1,0 +1,13 @@
+client:
+  hosts:
+    - 127.0.0.1
+  port: 9200
+  use_ssl: False
+  ssl_no_validate: False
+  timeout: 30
+  master_only: False
+
+logging:
+  loglevel: INFO
+  logformat: default
+  blacklist: ['elasticsearch', 'urllib3']

--- a/curator/delete_old_snapshots.yml
+++ b/curator/delete_old_snapshots.yml
@@ -1,0 +1,13 @@
+actions:
+  1:
+    action: delete_snapshots
+    description: delete snapshots older than 30 days
+    options:
+      repository: 'my_backup'
+      disable_action: False
+    filters:
+    - filtertype: age
+      source: creation_date
+      direction: older
+      unit: days
+      unit_count: 30

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -64,6 +64,7 @@ function template()
     mustache dockstore_launcher_config/compose.config templates/init_migration.sh.template > config/init_migration.sh
     mustache dockstore_launcher_config/compose.config templates/elasticsearch.yml > config/elasticsearch.yml
     mustache dockstore_launcher_config/compose.config templates/metricbeat.yml > config/metricbeat.yml
+    mustache dockstore_launcher_config/compose.config templates/essnapshot_backup.sh > scripts/essnapshot_backup.sh
     mustache dockstore_launcher_config/compose.config templates/search_verification.html > config/${GOOGLE_VERIFICATION_NAME}.html
 
     mkdir -p config/rules

--- a/scripts/essnapshot_backup.sh
+++ b/scripts/essnapshot_backup.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 set -x
-set -e
+
+WEBHOOK_URL=''
 
 # Corresponding cronjob is "0 0 * * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh"
 
-curl -X PUT "localhost:9200/_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E"
-aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 sync /home/ubuntu/compose_setup/essnapshot s3://logstash-elasticdata/essnapshot
-
-echo "Uploaded essnapshot to https://object.cancercollaboratory.org:9080 s3://logstash-elasticdata/essnapshot"
+curl -X PUT "localhost:9200/_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E" | grep accepted\":true
+if [ $? -ne 0 ]
+then
+	curl -X POST -H 'Content-type: application/json' --data '{"text":"Taking snapshot failed."}' $WEBHOOK_URL
+else
+	aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 sync /home/ubuntu/compose_setup/essnapshot2 s3://logstash-elasticdata/essnapshot2
+	if [ $? -ne 0 ]
+	then
+		curl -X POST -H 'Content-type: application/json' --data '{"text":"Sending snapshot to s3 failed."}' $WEBHOOK_URL
+	fi
+fi

--- a/templates/essnapshot_backup.sh
+++ b/templates/essnapshot_backup.sh
@@ -10,7 +10,7 @@ if [ $? -ne 0 ]
 then
 	curl -X POST -H 'Content-type: application/json' --data '{"text":"Taking snapshot failed."}' $WEBHOOK_URL
 else
-	aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 sync /home/ubuntu/compose_setup/essnapshot s3://logstash-elasticdata/essnapshot
+	aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 cp --recursive /home/ubuntu/compose_setup/essnapshot s3://logstash-elasticdata/essnapshot
 	if [ $? -ne 0 ]
 	then
 		curl -X POST -H 'Content-type: application/json' --data '{"text":"Sending snapshot to s3 failed."}' $WEBHOOK_URL

--- a/templates/essnapshot_backup.sh
+++ b/templates/essnapshot_backup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -x
 
-WEBHOOK_URL=''
+WEBHOOK_URL='{{SLACK_URL}}'
 
 # Corresponding cronjob is "0 0 * * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh"
 
@@ -10,7 +10,7 @@ if [ $? -ne 0 ]
 then
 	curl -X POST -H 'Content-type: application/json' --data '{"text":"Taking snapshot failed."}' $WEBHOOK_URL
 else
-	aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 sync /home/ubuntu/compose_setup/essnapshot2 s3://logstash-elasticdata/essnapshot2
+	aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 sync /home/ubuntu/compose_setup/essnapshot s3://logstash-elasticdata/essnapshot
 	if [ $? -ne 0 ]
 	then
 		curl -X POST -H 'Content-type: application/json' --data '{"text":"Sending snapshot to s3 failed."}' $WEBHOOK_URL

--- a/templates/essnapshot_backup.sh
+++ b/templates/essnapshot_backup.sh
@@ -5,6 +5,7 @@ WEBHOOK_URL='{{SLACK_URL}}'
 
 # Corresponding cronjob is "0 0 * * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh"
 
+curator --config /home/ubuntu/compose_setup/curator/curator.yml /home/ubuntu/compose_setup/curator/delete_old_snapshots.yml
 curl -X PUT "localhost:9200/_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E" | grep accepted\":true
 if [ $? -ne 0 ]
 then


### PR DESCRIPTION
Adds Slack Notification when either taking snapshot or uploading snapshot is broken.

Current situation is taking the snapshot and uploading all snapshots daily (overwriting the existing set of snapshots).  All snapshots are retained forever.

In comparison, Elastic cloud takes a snapshot every 30 mins and retains each snapshot for 48 hrs

Edit: added elastic curator to delete older than 30 days snapshots