### PR TITLE
Forward client IP

### DIFF
--- a/templates/default.nginx_https.conf.template
+++ b/templates/default.nginx_https.conf.template
@@ -42,6 +42,11 @@ server {
     add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
     add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    proxy_set_header  Host $host;
+    proxy_set_header  X-Real-IP $remote_addr;
+    proxy_set_header  X-Forwarded-Proto https;
+    proxy_set_header  X-Forwarded-For $remote_addr;
+    proxy_set_header  X-Forwarded-Host $remote_addr;
 
     # used to redirect swagger.json as retrieved by swagger ui without changes
     location = /swagger.json {


### PR DESCRIPTION
For ga4gh/dockstore#1898

Forward the client IP.  Appears to work when tested.