### PR TITLE
Feature/take snapshot

### DIFF
--- a/DEV-README.md
+++ b/DEV-README.md
@@ -29,9 +29,19 @@ Get the admin port of Dockstore dropwizard (likely 8081 by default).  Make sure 
 Rules should be added/modified in the [templates/rules](templates/rules) directory because SLACK_URL requires templating. Rules can be temporarily added/modified in `config/rules` or via the elasticAlert kibana plugin in the kibana dashboard.
 
 ## Elasticsearch backup
+Install elasticsearch-curator because it makes life a lot easier.
+```
+pip install elasticsearch-curator==5.6.0
+``` 
+Check that `curator_cli` and `curator` command works.
 
 ### Snapshot repository creation:
-Make sure elasticsearch-logstash has essnapshot write permissions. Run this commands from within the docker-compose.dev.yml server.
+Make sure elasticsearch-logstash has essnapshot write permissions. 
+```
+sudo chown -R ubuntu:ubuntu essnapshot
+sudo chmod -R 775 essnapshot
+```
+Run this commands from within the docker-compose.dev.yml server.
 ```
 curl -X PUT "localhost:9200/_snapshot/my_backup" -H 'Content-Type: application/json' -d'
 {
@@ -42,6 +52,10 @@ curl -X PUT "localhost:9200/_snapshot/my_backup" -H 'Content-Type: application/j
     }
 }
 '
+If your essnapshot directory has snapshots already, double check by using:
+```
+curator_cli show_snapshots --repository my_backup
+```
 ```
 
 ### Creating daily snapshots
@@ -50,13 +64,17 @@ curl -X PUT "localhost:9200/_snapshot/my_backup" -H 'Content-Type: application/j
 ### Delete snapshot
 `curl -X DELETE "localhost:9200/_snapshot/my_backup/snapshot-2018.09.26"`
 
-Alternatively, you can delete old snapshots automatically using curator.  Install with `pip install elasticsearch-curator==5.6.0` then delete old with `curator --config curator.yml delete_old_snapshots.yml` inside the curator directory.
+Alternatively, you can delete old snapshots automatically using curator.  Delete old snapshots with `curator --config curator.yml delete_old_snapshots.yml` inside the curator directory.
 
 
-### Restoring snapshots
-- `curl -X POST "localhost:9200/_all/_close"` 
-- `curl -X POST "localhost:9200/_snapshot/my_backup/snapshot-2018.09.26/_restore"`
+### Restoring snapshots procedure
+Before bringing up elasticsearch-logstash, download the newest zip file from s3 and extract its contents into the essnapshot directory. Then follow the [Snapshot repository creation](#snapshot-repository-creation) section and ensure the snapshots are readable.  Restart elasticsearch-logstash if not snapshots are found.  Perform the snapshot restore:
+- `curl -X POST "localhost:9200/_all/_close"`
+Replace "snapshot-2019.01.04" with the actual snapshot name
+- `curl -X POST "localhost:9200/_snapshot/my_backup/snapshot-2019.01.04/_restore?wait_for_completion=true"`
 - `curl -X POST "localhost:9200/_all/_open"`
+
+Double check in Kibana that the amount of hits are sane
 
 ## Kibana setup
 Generally, snapshot repo create and then snapshot restore should be used first.  In the event that there's no snapshot, export.json can be used to recover everything except for the actual logging data.

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -6,7 +6,8 @@ There are 3 different sets of metric logs being sent to logstash's elasticsearch
 
 ## Ports
 - Port 9200 must be opened for metricbeats to send data to elasticsearch directly
-- Port 5055 must be opened for webservice to send data to logstash
+- Port 5055 must be opened for the production webservice to send data to logstash
+- Port 5066 must be opened for the staging webservice to send data to logstash
 - Port 5601 must be opened for developers to view the kibana dashboard
 
 ## Apache HTTP Logs

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -50,7 +50,7 @@ curl -X PUT "localhost:9200/_snapshot/my_backup" -H 'Content-Type: application/j
 ### Delete snapshot
 `curl -X DELETE "localhost:9200/_snapshot/my_backup/snapshot-2018.09.26"`
 
-Alternatively, you can delete old snapshots automatically using curator.  Install with `pip install elasticsearch-curator` then delete old with `curator --config curator.yml delete_old_snapshots.yml` inside the curator directory.
+Alternatively, you can delete old snapshots automatically using curator.  Install with `pip install elasticsearch-curator==5.6.0` then delete old with `curator --config curator.yml delete_old_snapshots.yml` inside the curator directory.
 
 
 ### Restoring snapshots

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -53,10 +53,10 @@ curl -X PUT "localhost:9200/_snapshot/my_backup" -H 'Content-Type: application/j
     }
 }
 '
+```
 If your essnapshot directory has snapshots already, double check by using:
 ```
 curator_cli show_snapshots --repository my_backup
-```
 ```
 
 ### Creating daily snapshots

--- a/curator/take_snapshots.yml
+++ b/curator/take_snapshots.yml
@@ -1,0 +1,34 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: snapshot
+    description: >-
+      Snapshot logstash- prefixed indices older than 1 day (based on index
+      creation_date) with the default snapshot name pattern of
+      'curator-%Y%m%d%H%M%S'.  Wait for the snapshot to complete.  Do not skip
+      the repository filesystem access check.  Use the other options to create
+      the snapshot.
+    options:
+      repository: 'my_backup'
+      # Leaving name blank will result in the default 'curator-%Y%m%d%H%M%S'
+      name:
+      ignore_unavailable: False
+      include_global_state: True
+      partial: False
+      wait_for_completion: True
+      skip_repo_fs_check: False
+      timeout_override:
+      continue_if_exception: False
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms1500m -Xmx1500m"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
         soft: -1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,6 +29,7 @@ services:
       XPACK_MONITORING_ELASTICSEARCH_URL: "elasticsearch-logstash:9200"
     ports:
       - "5055:5055"
+      - "5066:5066"
   kibana:
     build:
       context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,12 +6,11 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms1500m -Xmx1500m"
     ulimits:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 1g
     ports:
       - "9200:9200"
       - "9300:9300"
@@ -44,7 +43,7 @@ services:
     environment:
       XPACK_SECURITY_ENABLED: "false"
   elastalert:
-    image: bitsensor/elastalert:latest
+    image: bitsensor/elastalert:0.0.14
     environment:
       ES_HOST: "elasticsearch-logstash"
     depends_on:

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -19,6 +19,7 @@ MSG
 
 run_dockstore_launcher=''
 PUBLIC_LAUNCHER_IP_ADDRESS=''
+PRODUCTION=''
 DOCKSTORE_VERSION=''
 DOCKSTORE_UI2_VERSION=''
 GITHUB_CLIENT2_ID=''
@@ -189,7 +190,8 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
     read run_dockstore_launcher
     # If the user would like to run dockstore_launcher, then we have to get some config settings from them OR read them from an existing file
     if [ "${run_dockstore_launcher^^}" = 'Y' ] ; then
-
+	production='production'
+	ask_question "Are you deploying on production (true or false)?" "$PRODUCTION" "Dockstore version" $production
         dockstore_version='dockstore_version'
         ask_question "What version of Dockstore do you wish to deploy?" "$DOCKSTORE_VERSION" "Dockstore version" $dockstore_version
 
@@ -273,6 +275,7 @@ while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" 
         cat > dockstore_launcher_config/compose.config <<CONFIG
 {
 "PUBLIC_LAUNCHER_IP_ADDRESS":"`curl http://169.254.169.254/latest/meta-data/public-ipv4`",
+"PRODUCTION":${production},
 "DOCKSTORE_VERSION":"${dockstore_version}",
 "DOCKSTORE_UI2_VERSION":"${dockstore_ui2_version}",
 "GITHUB_CLIENT2_ID":"${github_client2_id}",

--- a/staticConfig/logsToElastic.conf
+++ b/staticConfig/logsToElastic.conf
@@ -1,6 +1,6 @@
 input {
   tcp {
-    port => 5054
+    port => 5066
     codec => json
     type => staginglogs
   }

--- a/staticConfig/logsToElastic.conf
+++ b/staticConfig/logsToElastic.conf
@@ -189,6 +189,9 @@ filter {
 
 
 output {
-  elasticsearch { hosts => ["elasticsearch-logstash:9200"] }
+  elasticsearch { 
+    hosts => ["elasticsearch-logstash:9200"] 
+    index => "%{host}-logstash-%{+YYYY.MM.dd}"
+  }
   stdout { codec => rubydebug }
 }

--- a/staticConfig/logsToElastic.conf
+++ b/staticConfig/logsToElastic.conf
@@ -1,7 +1,13 @@
 input {
   tcp {
+    port => 5054
+    codec => json
+    type => staginglogs
+  }
+  tcp {
     port => 5055
     codec => json
+    type => productionlogs
   }
   file {
     path => "/tmp/access_log"
@@ -189,9 +195,15 @@ filter {
 
 
 output {
-  elasticsearch { 
-    hosts => ["elasticsearch-logstash:9200"] 
-    index => "%{host}-logstash-%{+YYYY.MM.dd}"
+  if [type]=="staginglogs" {
+    elasticsearch { 
+      hosts => ["elasticsearch-logstash:9200"] 
+      index => "staging-logstash-%{+YYYY.MM.dd}"
+    }
+  } else {
+    elasticsearch {
+      hosts => ["elasticsearch-logstash:9200"]
+    }
   }
   stdout { codec => rubydebug }
 }

--- a/templates/essnapshot_backup.sh
+++ b/templates/essnapshot_backup.sh
@@ -8,7 +8,7 @@ mkdir -p /home/ubuntu/compose_setup/logs
 # "0 0 * * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh daily &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
 # "15 0 * * 0 /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh weekly &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
 # "30 0 1 * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh monthly &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
-curator --config /home/ubuntu/compose_setup/curator/curator.yml /home/ubuntu/compose_setup/curator/delete_old_snapshots.yml
+/home/ubuntu/.local/bin/curator --config /home/ubuntu/compose_setup/curator/curator.yml /home/ubuntu/compose_setup/curator/delete_old_snapshots.yml
 curl -X PUT "localhost:9200/_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E?wait_for_completion=true" | grep accepted\":true
 if [ $? -ne 0 ]
 then
@@ -18,7 +18,7 @@ fi
 
 cd /home/ubuntu/compose_setup
 zip -r essnapshot-$1.zip essnapshot
-previoussize=`aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 ls s3://logstash-elasticdata/essnapshot-$1.zip --summarize | grep 'Total Size:' | awk '{print $3}'`
+previoussize=`/home/ubuntu/.local/bin/aws s3 --endpoint-url https://object.cancercollaboratory.org:9080 ls s3://logstash-elasticdata/essnapshot-$1.zip --summarize | grep 'Total Size:' | awk '{print $3}'`
 currentsize=`stat --printf="%s" essnapshot-$1.zip`
 
 if [ $previoussize -gt $currentsize ]

--- a/templates/essnapshot_backup.sh
+++ b/templates/essnapshot_backup.sh
@@ -11,7 +11,7 @@ mkdir -p /home/ubuntu/compose_setup/logs
 # "15 0 * * 0 /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh weekly &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
 # "30 0 1 * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh monthly &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
 /home/ubuntu/.local/bin/curator --config /home/ubuntu/compose_setup/curator/curator.yml /home/ubuntu/compose_setup/curator/delete_old_snapshots.yml
-curl -X PUT "localhost:9200/_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E?wait_for_completion=true" | grep accepted\":true
+/home/ubuntu/.local/bin/curator --config /home/ubuntu/compose_setup/curator/curator.yml /home/ubuntu/compose_setup/curator/take_snapshots.yml
 if [ $? -ne 0 ]
 then
     curl -X POST -H 'Content-type: application/json' --data '{"text":"Taking snapshot failed."}' $WEBHOOK_URL

--- a/templates/essnapshot_backup.sh
+++ b/templates/essnapshot_backup.sh
@@ -5,6 +5,8 @@ WEBHOOK_URL='{{SLACK_URL}}'
 
 mkdir -p /home/ubuntu/compose_setup/logs
 # Corresponding cronjobs are:
+# SHELL=/bin/bash
+# PATH=<echo $PATH on a user that has access to all commands to find out>
 # "0 0 * * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh daily &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
 # "15 0 * * 0 /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh weekly &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"
 # "30 0 1 * * /bin/bash /home/ubuntu/compose_setup/scripts/essnapshot_backup.sh monthly &> /home/ubuntu/compose_setup/logs/`/bin/date +\%Y-\%m-\%d.\%H:\%M:\%S`-cron.log"

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -97,5 +97,5 @@ server:
     appenders:
       - type: logstash
         host: {{ LOGSTASH_HOST }}
-        port: 5055
+        port: {{#PRODUCTION}}5055{{/PRODUCTION}}{{^PRODUCTION}}5066{{/PRODUCTION}}
 {{/LOGSTASH}}


### PR DESCRIPTION
For partial ga4gh/dockstore#2024

- more detailed restore backup procedure
- mentions possible essnapshot permissions issue
- specifies elasticsearch-curator version
- specifies elastalert version
- take snapshots with curator because it's easier to filter indexes that way (snapshot name pattern have been changed.  Though still fairly easy to understand the dates)
- use absolute path for aws cli just in case...even though PATH is now set in crontab
- 5055 for production logging, 5066 for staging logging