### PR TITLE
Working on aws

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+essnapshot

--- a/curator/take_snapshots.yml
+++ b/curator/take_snapshots.yml
@@ -1,0 +1,34 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+#
+# Also remember that all examples have 'disable_action' set to True.  If you
+# want to use this action as a template, be sure to set this to False after
+# copying it.
+actions:
+  1:
+    action: snapshot
+    description: >-
+      Snapshot logstash- prefixed indices older than 1 day (based on index
+      creation_date) with the default snapshot name pattern of
+      'curator-%Y%m%d%H%M%S'.  Wait for the snapshot to complete.  Do not skip
+      the repository filesystem access check.  Use the other options to create
+      the snapshot.
+    options:
+      repository: 'my_backup'
+      # Leaving name blank will result in the default 'curator-%Y%m%d%H%M%S'
+      name:
+      ignore_unavailable: False
+      include_global_state: True
+      partial: False
+      wait_for_completion: True
+      skip_repo_fs_check: False
+      timeout_override:
+      continue_if_exception: False
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,16 +6,18 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
     ulimits:
       memlock:
         soft: -1
         hard: -1
-    mem_limit: 1g
+    mem_limit: 1500m
     ports:
       - "9200:9200"
-      - "9300:9300"
+    expose:
+      - "9300"
     volumes:
+      - ./config/jvm.options.es:/usr/share/elasticsearch/config/jvm.options
       - esdata2:/usr/share/elasticsearch/data
       - ./staticConfig/elasticsearchLogstash.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ./essnapshot:/mount/backups
@@ -26,34 +28,54 @@ services:
       - elasticsearch-logstash
     volumes:
       - ./staticConfig/logsToElastic.conf:/usr/share/logstash/pipeline/logsToElastic.conf
+      - ./config/jvm.options.logstash:/usr/share/logstash/config/jvm.options
     environment:
-      XPACK_MONITORING_ELASTICSEARCH_URL: "elasticsearch-logstash:9200"
+      - XPACK_MONITORING_ELASTICSEARCH_URL=elasticsearch-logstash:9200
+      - LS_JAVA_OPTS=-Xms512m -Xmx512m
     ports:
       - "5055:5055"
-  kibana:
-    build:
-      context: .
-      dockerfile: templates/kibanaDockerfile
-    restart: always
-    volumes:
-      - ./staticConfig/kibana.yml:/usr/share/kibana/config/kibana.yml
-    ports:
-      - "5601:5601"
-    depends_on:
-      - elasticsearch-logstash
-    environment:
-      XPACK_SECURITY_ENABLED: "false"
-  elastalert:
-    image: bitsensor/elastalert:latest
-    environment:
-      ES_HOST: "elasticsearch-logstash"
-    depends_on:
-      - elasticsearch-logstash
-    restart: always
-    ports:
-      - "3030:3030"
-    volumes:
-      - ./config/rules:/opt/elastalert/rules
+    mem_limit: 1g
+#  kibana:
+#    build:
+#      context: .
+#      dockerfile: templates/kibanaDockerfile
+#    restart: always
+#    volumes:
+#      - ./staticConfig/kibana.yml:/usr/share/kibana/config/kibana.yml
+#    expose:
+#      - "5601"
+#    depends_on:
+#      - elasticsearch-logstash
+#    environment:
+#      -  XPACK_SECURITY_ENABLED=false
+#    mem_limit: 1500m 
+#  elastalert:
+#    image: bitsensor/elastalert:0.0.14
+#    environment:
+#      ES_HOST: "elasticsearch-logstash"
+#    depends_on:
+#      - elasticsearch-logstash
+#    restart: always
+#    expose:
+#      - "3030"
+#    volumes:
+#      - ./config/rules:/opt/elastalert/rules
+#    mem_limit: 500m
+  # courtesy of https://blog.t1cg.io/post/elk-aws-deployment.html#installing-docker-nginx-certbot-and-the-elk-stack
+#    nginx:
+#    build:
+#      context: nginx/
+#    restart: always
+#    ports:
+#      - "35943:443"
+#      - "80:80"
+#    volumes:
+#      - "/etc/letsencrypt/live/logging.dockstore.org/fullchain.pem:/etc/letsencrypt/live/logging.dockstore.org/fullchain.pem"
+#      - "/etc/letsencrypt/live/logging.dockstore.org/privkey.pem:/etc/letsencrypt/live/logging.dockstore.org/privkey.pem"
+#      - "./nginx/kibana.htpasswd:/etc/nginx/conf.d/kibana.htpasswd"
+#      - "./nginx/default.conf:/etc/nginx/conf.d/default.conf"
+#    depends_on:
+#      - kibana
 volumes:
   esdata2:
     driver: local

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
       - esdata2:/usr/share/elasticsearch/data
       - ./staticConfig/elasticsearchLogstash.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ./essnapshot:/mount/backups
-    command: ["dockerize", "-wait-retry-interval", "60s", "-timeout", "3600s",  "-wait", "tcp://kibana:5601", "/usr/local/bin/docker-entrypoint.sh"]
+        #    command: ["dockerize", "-wait-retry-interval", "60s", "-timeout", "3600s",  "-wait", "tcp://kibana:5601", "/usr/local/bin/docker-entrypoint.sh"]
   logstash:
     build:
       context: .
@@ -40,7 +40,7 @@ services:
     ports:
       - "5055:5055"
     mem_limit: 1g
-    command: ["dockerize", "-wait-retry-interval", "60s", "-timeout", "3600s", "-wait", "tcp://kibana:5601", "/usr/local/bin/docker-entrypoint"]
+    #    command: ["dockerize", "-wait-retry-interval", "60s", "-timeout", "3600s", "-wait", "tcp://kibana:5601", "/usr/local/bin/docker-entrypoint"]
   kibana:
     build:
       context: .

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,9 @@
 version: '2'
 services:
   elasticsearch-logstash:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.0
+    build:
+      context: .
+      dockerfile: templates/esDockerfile
     restart: always
     environment:
       - cluster.name=docker-cluster
@@ -21,8 +23,11 @@ services:
       - esdata2:/usr/share/elasticsearch/data
       - ./staticConfig/elasticsearchLogstash.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ./essnapshot:/mount/backups
+    command: ["dockerize", "-wait-retry-interval", "60s", "-timeout", "3600s",  "-wait", "tcp://kibana:5601", "/usr/local/bin/docker-entrypoint.sh"]
   logstash:
-    image: docker.elastic.co/logstash/logstash:6.4.0
+    build:
+      context: .
+      dockerfile: templates/logstashDockerfile
     restart: always
     depends_on:
       - elasticsearch-logstash
@@ -35,20 +40,20 @@ services:
     ports:
       - "5055:5055"
     mem_limit: 1g
-#  kibana:
-#    build:
-#      context: .
-#      dockerfile: templates/kibanaDockerfile
-#    restart: always
-#    volumes:
-#      - ./staticConfig/kibana.yml:/usr/share/kibana/config/kibana.yml
-#    expose:
-#      - "5601"
-#    depends_on:
-#      - elasticsearch-logstash
-#    environment:
-#      -  XPACK_SECURITY_ENABLED=false
-#    mem_limit: 1500m 
+    command: ["dockerize", "-wait-retry-interval", "60s", "-timeout", "3600s", "-wait", "tcp://kibana:5601", "/usr/local/bin/docker-entrypoint"]
+  kibana:
+    build:
+      context: .
+      dockerfile: templates/kibanaDockerfile
+    restart: always
+    volumes:
+      - ./staticConfig/kibana.yml:/usr/share/kibana/config/kibana.yml
+    expose:
+      - "5601"
+    depends_on:
+      - elasticsearch-logstash
+    environment:
+      -  XPACK_SECURITY_ENABLED=false
 #  elastalert:
 #    image: bitsensor/elastalert:0.0.14
 #    environment:
@@ -62,20 +67,20 @@ services:
 #      - ./config/rules:/opt/elastalert/rules
 #    mem_limit: 500m
   # courtesy of https://blog.t1cg.io/post/elk-aws-deployment.html#installing-docker-nginx-certbot-and-the-elk-stack
-#    nginx:
-#    build:
-#      context: nginx/
-#    restart: always
-#    ports:
-#      - "35943:443"
-#      - "80:80"
-#    volumes:
-#      - "/etc/letsencrypt/live/logging.dockstore.org/fullchain.pem:/etc/letsencrypt/live/logging.dockstore.org/fullchain.pem"
-#      - "/etc/letsencrypt/live/logging.dockstore.org/privkey.pem:/etc/letsencrypt/live/logging.dockstore.org/privkey.pem"
-#      - "./nginx/kibana.htpasswd:/etc/nginx/conf.d/kibana.htpasswd"
-#      - "./nginx/default.conf:/etc/nginx/conf.d/default.conf"
-#    depends_on:
-#      - kibana
+  nginx:
+    build:
+      context: nginx/
+    restart: always
+    ports:
+      - "35943:443"
+      - "80:80"
+    volumes:
+      - "/etc/letsencrypt/live/logging.dockstore.org/fullchain.pem:/etc/letsencrypt/live/logging.dockstore.org/fullchain.pem"
+      - "/etc/letsencrypt/live/logging.dockstore.org/privkey.pem:/etc/letsencrypt/live/logging.dockstore.org/privkey.pem"
+      - "./nginx/kibana.htpasswd:/etc/nginx/conf.d/kibana.htpasswd"
+      - "./nginx/default.conf:/etc/nginx/conf.d/default.conf"
+    depends_on:
+      - kibana
 volumes:
   esdata2:
     driver: local

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -66,6 +66,9 @@ function template()
     mustache dockstore_launcher_config/compose.config templates/metricbeat.yml > config/metricbeat.yml
     mustache dockstore_launcher_config/compose.config templates/essnapshot_backup.sh > scripts/essnapshot_backup.sh
     mustache dockstore_launcher_config/compose.config templates/search_verification.html > config/${GOOGLE_VERIFICATION_NAME}.html
+    
+    mustache dockstore_launcher_config/compose.config templates/jvm.options.es.template > config/jvm.options.es
+    mustache dockstore_launcher_config/compose.config templates/jvm.options.logstash.template > config/jvm.options.logstash
 
     mkdir -p config/rules
     for f in $(ls templates/rules/); do mustache dockstore_launcher_config/compose.config templates/rules/$f > config/rules/$f; done

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,20 @@
+FROM nginx:latest
+
+USER root
+
+RUN apt-get update
+
+RUN apt-get install -y git
+
+RUN git clone https://github.com/certbot/certbot /opt/letsencrypt
+
+RUN mkdir -p /var/www/letsencrypt/
+
+RUN chgrp -Rf www-data /var/www/letsencrypt/
+
+RUN mkdir -p /var/www/html
+
+RUN mkdir -p /.well-known/acme-challenge/
+
+RUN chown 755 /.well-known/acme-challenge/
+

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,31 @@
+server {
+  listen *:443 ;
+  ssl on;
+  ssl_certificate /etc/letsencrypt/live/logging.dockstore.org/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/logging.dockstore.org/privkey.pem;
+
+  location / {
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/conf.d/kibana.htpasswd;
+    proxy_pass http://kibana:5601;
+  }
+}
+
+server {
+  listen *:444 ;
+  ssl on;
+  ssl_certificate /etc/letsencrypt/live/logging.dockstore.org/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/logging.dockstore.org/privkey.pem;
+
+  location / {
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/conf.d/kibana.htpasswd;
+    proxy_pass http://elasticsearch-logstash:9200;
+  }
+}
+
+server {
+  listen 80 default_server;
+  server_name _;
+  return 301 https://$host$request_uri;
+}

--- a/templates/esDockerfile
+++ b/templates/esDockerfile
@@ -1,5 +1,6 @@
 FROM  docker.elastic.co/elasticsearch/elasticsearch:6.4.0
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+# enable the following lines if you need dockerize
+# ENV DOCKERIZE_VERSION v0.6.1
+# RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+#    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+#    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/templates/esDockerfile
+++ b/templates/esDockerfile
@@ -1,0 +1,5 @@
+FROM  docker.elastic.co/elasticsearch/elasticsearch:6.4.0
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/templates/jvm.options.es.template
+++ b/templates/jvm.options.es.template
@@ -1,0 +1,106 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+# disable to enable config via environment variables
+#-Xms1g
+#-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2

--- a/templates/jvm.options.logstash.template
+++ b/templates/jvm.options.logstash.template
@@ -1,0 +1,78 @@
+## JVM configuration
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+# disable to enable config via environment variables
+#-Xms1g
+#-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseParNewGC
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## Locale
+# Set the locale language
+#-Duser.language=en
+
+# Set the locale country
+#-Duser.country=US
+
+# Set the locale variant, if any
+#-Duser.variant=
+
+## basic
+
+# set the I/O temp directory
+#-Djava.io.tmpdir=$HOME
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+#-Djna.nosys=true
+
+# Turn on JRuby invokedynamic
+-Djruby.compile.invokedynamic=true
+# Force Compilation
+-Djruby.jit.threshold=0
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps
+# ensure the directory exists and has sufficient space
+#-XX:HeapDumpPath=${LOGSTASH_HOME}/heapdump.hprof
+
+## GC logging
+#-XX:+PrintGCDetails
+#-XX:+PrintGCTimeStamps
+#-XX:+PrintGCDateStamps
+#-XX:+PrintClassHistogram
+#-XX:+PrintTenuringDistribution
+#-XX:+PrintGCApplicationStoppedTime
+
+# log GC status to a file with time stamps
+# ensure the directory exists
+#-Xloggc:${LS_GC_LOG_FILE}
+
+# Entropy source for randomness
+-Djava.security.egd=file:/dev/urandom

--- a/templates/kibanaDockerfile
+++ b/templates/kibanaDockerfile
@@ -1,2 +1,4 @@
 FROM docker.elastic.co/kibana/kibana:6.4.0
+ENV XPACK_SECURITY_ENABLED false
 RUN bin/kibana-plugin install https://github.com/bitsensor/elastalert-kibana-plugin/releases/download/1.0.1/elastalert-kibana-plugin-1.0.1-6.4.0.zip
+RUN /usr/local/bin/kibana-docker 2>&1 | grep -m 1 "Optimization of .* complete"

--- a/templates/logstashDockerfile
+++ b/templates/logstashDockerfile
@@ -1,0 +1,8 @@
+FROM docker.elastic.co/logstash/logstash:6.4.0
+USER root
+RUN yum -y install wget
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+USER logstash

--- a/templates/logstashDockerfile
+++ b/templates/logstashDockerfile
@@ -1,8 +1,9 @@
 FROM docker.elastic.co/logstash/logstash:6.4.0
-USER root
-RUN yum -y install wget
-ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-USER logstash
+# enable the following lines to use dockerize
+# USER root
+# RUN yum -y install wget
+# ENV DOCKERIZE_VERSION v0.6.1
+# RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+#    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+#    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+# USER logstash

--- a/templates/vm.options.es.template
+++ b/templates/vm.options.es.template
@@ -1,0 +1,105 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+#-Xms1g
+#-Xmx1g
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+-XX:HeapDumpPath=data
+
+# specify an alternative path for JVM fatal error logs
+-XX:ErrorFile=logs/hs_err_pid%p.log
+
+## JDK 8 GC logging
+
+8:-XX:+PrintGCDetails
+8:-XX:+PrintGCDateStamps
+8:-XX:+PrintTenuringDistribution
+8:-XX:+PrintGCApplicationStoppedTime
+8:-Xloggc:logs/gc.log
+8:-XX:+UseGCLogFileRotation
+8:-XX:NumberOfGCLogFiles=32
+8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+9-:-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+9-:-Djava.locale.providers=COMPAT
+
+# temporary workaround for C2 bug with JDK 10 on hardware with AVX-512
+10-:-XX:UseAVX=2


### PR DESCRIPTION
* I needed these changes to get everything up to elastalert working on a AWS t2.medium
  * lots of memory limits and fixes to vmoptions (otherwise these containers ignore memory limits)
* normally don't leave in comments, but I think there's a good change we'll reactivate dockerize later 
* need essnapshot dockerignored (messes up build context)
* adds https support

Will need follow-up with https://github.com/ga4gh/dockstore/issues/2024
