### PR TITLE
Feature/elastalert update

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -68,6 +68,7 @@ services:
       - "3030"
     volumes:
       - ./config/rules:/opt/elastalert/rules
+      - ./staticConfig/elastalert.yaml:/opt/elastalert/config.yaml
     mem_limit: 500m
   # courtesy of https://blog.t1cg.io/post/elk-aws-deployment.html#installing-docker-nginx-certbot-and-the-elk-stack
   nginx:

--- a/staticConfig/elastalert.yaml
+++ b/staticConfig/elastalert.yaml
@@ -1,0 +1,49 @@
+# The elasticsearch hostname for metadata writeback
+# Note that every rule can have its own elasticsearch host
+es_host: localhost
+
+# The elasticsearch port
+es_port: 9200
+
+# This is the folder that contains the rule yaml files
+# Any .yaml file will be loaded as a rule
+rules_folder: rules
+
+# How often ElastAlert will query elasticsearch
+# The unit can be anything from weeks to seconds
+run_every:
+  minutes: 5
+
+# ElastAlert will buffer results from the most recent
+# period of time, in case some log sources are not in real time
+buffer_time:
+  minutes: 5
+
+# Optional URL prefix for elasticsearch
+#es_url_prefix: elasticsearch
+
+# Connect with TLS to elasticsearch
+#use_ssl: True
+
+# Verify TLS certificates
+#verify_certs: True
+
+# GET request with body is the default option for Elasticsearch.
+# If it fails for some reason, you can pass 'GET', 'POST' or 'source'.
+# See http://elasticsearch-py.readthedocs.io/en/master/connection.html?highlight=send_get_body_as#transport
+# for details
+#es_send_get_body_as: GET
+
+# Option basic-auth username and password for elasticsearch
+#es_username: someusername
+#es_password: somepassword
+
+# The index on es_host which is used for metadata storage
+# This can be a unmapped index, but it is recommended that you run
+# elastalert-create-index to set a mapping
+writeback_index: elastalert_status
+
+# If an alert fails for some reason, ElastAlert will retry
+# sending the alert until this time period has elapsed
+alert_time_limit:
+  days: 2

--- a/templates/rules/abnormalResponse.yaml
+++ b/templates/rules/abnormalResponse.yaml
@@ -9,7 +9,7 @@ type: frequency
 
 # (Required)
 # Index to search, wildcard supported
-index: logstash-*
+index: "*logstash-*"
 
 # (Required, frequency specific)
 # Alert when this many documents matching the query occur within a timeframe
@@ -17,6 +17,7 @@ num_events: 50
 
 # (Required, frequency specific)
 # num_events must occur within this amount of time to trigger an alert
+# When triggered, clears the counter
 timeframe:
   hours: 1
 
@@ -26,7 +27,7 @@ timeframe:
 # For more info: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl.html
 filter:
 - terms:
-    response: ["400", "404", "500"]
+    response: ["400", "401", "404", "500"]
 
 query_key:
   - host

--- a/templates/rules/noData.yaml
+++ b/templates/rules/noData.yaml
@@ -26,7 +26,7 @@ query_key:
   - host
 
 # Index to search, wildcard supported
-index: logstash-*
+index: "*logstash-*"
 
 alert_subject: "No data on dashboard"
 

--- a/templates/rules/noData.yaml
+++ b/templates/rules/noData.yaml
@@ -23,7 +23,7 @@ exponential_realert:
 doc_type: doc
 
 # Index to search, wildcard supported
-index: "logstash-*"
+index: logstash-*
 
 alert_subject: "No data on dashboard"
 

--- a/templates/rules/noDataStaging.yaml
+++ b/templates/rules/noDataStaging.yaml
@@ -1,7 +1,7 @@
 # Alert when no data has been received for more then 30 seconds.
 
 # Rule name, must be unique
-name: No Data Production
+name: No Data Staging
 
 # Type of alert.
 type: flatline
@@ -23,12 +23,12 @@ exponential_realert:
 doc_type: doc
 
 # Index to search, wildcard supported
-index: "logstash-*"
+index: "staging-logstash-*"
 
 alert_subject: "No data on dashboard"
 
 alert_text_type: alert_text_only
-alert_text: "The stack receives no data at Dockstore Production. It might be down :("
+alert_text: "The stack receives no data at Dockstore Staging. It might be down :("
 
 # The alert is use when a match is found
 alert:

--- a/templates/rules/noDataStaging.yaml
+++ b/templates/rules/noDataStaging.yaml
@@ -23,7 +23,7 @@ exponential_realert:
 doc_type: doc
 
 # Index to search, wildcard supported
-index: "staging-logstash-*"
+index: staging-logstash-*
 
 alert_subject: "No data on dashboard"
 

--- a/templates/rules/pathSpikes.yaml
+++ b/templates/rules/pathSpikes.yaml
@@ -6,14 +6,14 @@ type: spike
 
 # num_events must occur within this amount of time to trigger an alert
 timeframe: 
-  seconds: 60
-spike_height: 10
+  minutes: 5
+spike_height: 5
 spike_type: up
 threshold_cur: 10
 threshold_ref: 1
 
 # Index to search, wildcard supported
-index: logstash-*
+index: "*logstash-*"
 query_key: 
   - generalizedPath
   - host

--- a/templates/rules/sameUserCreateHostedWorkflow.yaml
+++ b/templates/rules/sameUserCreateHostedWorkflow.yaml
@@ -9,7 +9,7 @@ type: frequency
 
 # (Required)
 # Index to search, wildcard supported
-index: logstash-*
+index: "*logstash-*"
 
 # (Required, frequency specific)
 # Alert when this many documents matching the query occur within a timeframe

--- a/templates/rules/sameUserCreateHostedWorkflowVersions.yaml
+++ b/templates/rules/sameUserCreateHostedWorkflowVersions.yaml
@@ -9,7 +9,7 @@ type: frequency
 
 # (Required)
 # Index to search, wildcard supported
-index: logstash-*
+index: "*logstash-*"
 
 # (Required, frequency specific)
 # Alert when this many documents matching the query occur within a timeframe

--- a/templates/rules/sameUserPublishWorkflow.yaml
+++ b/templates/rules/sameUserPublishWorkflow.yaml
@@ -9,7 +9,7 @@ type: frequency
 
 # (Required)
 # Index to search, wildcard supported
-index: logstash-*
+index: "*logstash-*"
 
 # (Required, frequency specific)
 # Alert when this many documents matching the query occur within a timeframe


### PR DESCRIPTION
1. Give a custom elastalert config.yaml because the default one has too frequent query and buffer_time.  Used to be querying every 5 seconds, now it's query'ing every 5 minutes.
2. Update all the indexes in the rules because there's staging-logstash-* and logstash-* for staging logs and production logs respectively.
3. Split the noData rules into two because it's unable to figure out where it didn't receive logs from
4. Since the query rate is every 5 mins, changed spike to also be 5 mins.