### PR TITLE
Set maximum size of request body to 50k improved

### DIFF
--- a/templates/default.nginx_https.conf.template
+++ b/templates/default.nginx_https.conf.template
@@ -43,9 +43,6 @@ server {
     add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
-    # Limit body size of a request to 50K to protect Java server from DOS attacks.
-    client_max_body_size 50k;
-
     # used to redirect swagger.json as retrieved by swagger ui without changes
     location = /swagger.json {
         #proxy_pass 	http://webservice:8080/swagger.json;

--- a/templates/default.nginx_https.shared.conf.template
+++ b/templates/default.nginx_https.shared.conf.template
@@ -27,3 +27,6 @@ ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 ssl_prefer_server_ciphers on;
 ssl_ciphers "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS";
 {{/HTTPS}}
+
+# Limit body size of a request to 50K to protect Java server from DOS attacks.
+client_max_body_size 50k;


### PR DESCRIPTION
The previous commit only worked if a client was hitting
the API on port 443; it would not apply if the client
was hitting the API on port 8443.

Move the setting to default.nginx_https.shared.conf.template so
that both ports are covered.