### PR TITLE
Don't set CORS headers in nginx server

### DIFF
--- a/templates/default.nginx_https.conf.template
+++ b/templates/default.nginx_https.conf.template
@@ -37,10 +37,6 @@ server {
 
     expires $expires;
 
-    add_header 'Access-Control-Allow-Origin' '*';
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, OPTIONS';
-    add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-    add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # Limit body size of a request to 50K to protect Java server from DOS attacks.


### PR DESCRIPTION
The Java server already sets the the CORS headers using
CrossOriginFilter in DockstoreWebserviceApplication.java. Setting the
access-control-allow-origin-header to two values is not valid --
that was happening because the headers were being set twice.

The reason that this bug only occurred on port 443 and not on port
8443 is because the CORS headers were only set for the server on
port 4200, which maps to port 443 in docker-compose.yml.

The server section for port 8080, which maps to port 8443, was
and isn't setting the CORS headers.

Because only AJAX requests bring CORS into the equation for Dockstore,
see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#What_requests_use_CORS,
this should be safe to remove from nginx, as the only thing that
implements an API that AJAX requests can invoke, is the
webservice, which already handles CORS.