### PR TITLE
Don't explicitly specify webservice port

### DIFF
--- a/templates/dockstore.model.ts.template
+++ b/templates/dockstore.model.ts.template
@@ -3,14 +3,14 @@ export class Dockstore {
 
   // Please fill in HOSTNAME with your address
   static readonly HOSTNAME = 'http{{#HTTPS}}s{{/HTTPS}}://{{ DOMAIN_NAME }}';
-  static readonly API_PORT = '443';
+  //static readonly API_PORT = '443';
   static readonly UI_PORT = '443';
 
   // Discourse URL MUST end with a slash (/)
   static readonly DISCOURSE_URL = '{{ DISCOURSE_URL }}';
 
   static readonly LOCAL_URI = Dockstore.HOSTNAME + ':' + Dockstore.UI_PORT;
-  static readonly API_URI = Dockstore.HOSTNAME + ':' + Dockstore.API_PORT + '/api';
+  static readonly API_URI = Dockstore.HOSTNAME + '/api';
   static readonly DNASTACK_IMPORT_URL= 'https://app.dnastack.com/#/app/workflow/import/dockstore';
   static readonly FIRECLOUD_IMPORT_URL= '{{ FIRECLOUD_IMPORT_URL }}';
   static readonly DNANEXUS_IMPORT_URL = 'https://platform.dnanexus.com/panx/tools/import-workflow';


### PR DESCRIPTION
ga4gh/dockstore#1594

Commented out API_PORT instead of deleting it so the template
wouldn't look too different from the code in dockstore-ui2.
But did comment it out so TS compiler wouldn't complain
about unused variables.

Code to set API_URL is thus a little more straightforward,
although it does vary from code in dockstore-ui2. Seems
clearer though.