### PR TITLE
Remove duplicate build optimizer

### DIFF
--- a/templates/Dockerfile_ui2.template
+++ b/templates/Dockerfile_ui2.template
@@ -9,24 +9,26 @@ RUN apt-get update \
     wget \
     && apt-get clean
 
-#prerequisites
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g @angular/cli@7.0.4
-#npm
+# install nvm
+RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash
+
 RUN touch {{ DOCKSTORE_UI2_VERSION }}.out
 RUN git clone https://github.com/dockstore/dockstore-ui2.git
 WORKDIR /dockstore-ui2
-RUN git checkout {{ DOCKSTORE_UI2_VERSION }}
+RUN git checkout feature/preinstall
+
+# install node version from .nvmrc file
+run bash -i -c 'nvm install'
+
 
 COPY config/dockstore.model.ts /dockstore-ui2/src/app/shared/dockstore.model.ts
 COPY config/index.html /dockstore-ui2/src/index.html
 
-RUN CI=true npm ci
-ENV WEBSERVICE_VERSION {{ DOCKSTORE_VERSION }}
-RUN npm run-script prebuild
-RUN ng build --prod
+# install
+RUN bash -i -c 'npm run install'
 
+# build
+RUN bash -i -c 'npm run build.prod'
 
 FROM nginx:1.13.1
 

--- a/templates/Dockerfile_ui2.template
+++ b/templates/Dockerfile_ui2.template
@@ -9,10 +9,10 @@ RUN apt-get update \
     wget \
     && apt-get clean
 
-#prerequisities
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+#prerequisites
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs
-RUN npm install -g @angular/cli@6.0.2 --unsafe
+RUN npm install -g @angular/cli@7.0.4
 #npm
 RUN touch {{ DOCKSTORE_UI2_VERSION }}.out
 RUN git clone https://github.com/dockstore/dockstore-ui2.git
@@ -22,7 +22,7 @@ RUN git checkout {{ DOCKSTORE_UI2_VERSION }}
 COPY config/dockstore.model.ts /dockstore-ui2/src/app/shared/dockstore.model.ts
 COPY config/index.html /dockstore-ui2/src/index.html
 
-RUN npm install
+RUN CI=true npm ci
 ENV WEBSERVICE_VERSION {{ DOCKSTORE_VERSION }}
 RUN npm run-script prebuild
 RUN ng build --prod

--- a/templates/Dockerfile_ui2.template
+++ b/templates/Dockerfile_ui2.template
@@ -25,7 +25,7 @@ COPY config/index.html /dockstore-ui2/src/index.html
 RUN npm install
 ENV WEBSERVICE_VERSION {{ DOCKSTORE_VERSION }}
 RUN npm run-script prebuild
-RUN ng build --prod --build-optimizer
+RUN ng build --prod
 
 
 FROM nginx:1.13.1


### PR DESCRIPTION
`--prod` "deploys the production environment which enables production mode."  https://angular.io/guide/deployment#production-optimizations

In our angular.json:
```
              "optimization": true,
              "outputHashing": "all",
              "sourceMap": false,
              "extractCss": true,
              "namedChunks": false,
              "aot": true,
              "extractLicenses": true,
              "vendorChunk": false,
              "buildOptimizer": true,
```
So it looks like build optimizer is duplicated which does make it slower.

Updating node, Angular CLI version, silence npm ci too

Edit: Nope, the duplicate buildOptimizer does not make it slower/faster but something does

Using compatible versions (this branch):

Date: 2019-03-22T20:43:17.583Z
Hash: eaa7e349cab7f48edc6d
Time: 119212ms

Using incompatible versions (develop):

Date: 2019-03-22T20:48:38.267Z
Hash: eaa7e349cab7f48edc6d
Time: 152079ms