### PR TITLE
Remove redundant command, increase wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ before_install:
 language: bash
 
 install:
-- bash install_bootstrap --script
+- travis_wait 30 bash install_bootstrap --script
 - docker-compose version
-- docker-compose build


### PR DESCRIPTION
For ga4gh/dockstore#2264

`bash install_bootstrap` already runs `docker-composes build`

Increase travis wait time so that non-cached builds can still pass travis.  To be reverted once build is fixed.