### PR TITLE
relinquish ownership migration hookup

### DIFF
--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 {{#DATABASE_GENERATED}}
-java -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
-# this particular migration needs to run as postgre because only postgres can surrender ownership
-java -Ddw.database.user=postgres -Ddw.database.password=postgres  -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
+java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 {{^DATABASE_GENERATED}}
-java -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
-# this particular migration needs to run as postgre because only postgres can surrender ownership
-java -Ddw.database.user=postgres -Ddw.database.password=postgres  -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
+java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
+# this particular migration needs to run as postgres because only postgres can surrender ownership
+java -Ddw.database.user=postgres -Ddw.database.password=postgres  -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
+# future migrations will start here and should be run as dockstore

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -7,5 +7,5 @@ java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-
 java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 # this particular migration needs to run as postgres because only postgres can surrender ownership
-java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
+java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -7,5 +7,5 @@ java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-
 java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 # this particular migration needs to run as postgres because only postgres can surrender ownership
-java -Ddw.database.user=postgres -Ddw.database.password=postgres  -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
+java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -2,7 +2,11 @@
 
 {{#DATABASE_GENERATED}}
 java -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+# this particular migration needs to run as postgre because only postgres can surrender ownership
+java -Ddw.database.user=postgres -Ddw.database.password=postgres  -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
 {{/DATABASE_GENERATED}}
 {{^DATABASE_GENERATED}}
 java -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+# this particular migration needs to run as postgre because only postgres can surrender ownership
+java -Ddw.database.user=postgres -Ddw.database.password=postgres  -jar dockstore-webservice/target/dockstore-webservice-*.jar db migrate ~/.dockstore/dockstore17.yml --include 1.7.0.relinquish
 {{/DATABASE_GENERATED}}

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -71,10 +71,10 @@ database:
   driverClass: org.postgresql.Driver
 
   # the username
-  user: postgres
+  user: dockstore
 
   # the password
-  password: postgres
+  password: dockstore
 
   # the JDBC URL
   url: jdbc:postgresql://postgres:5432/postgres


### PR DESCRIPTION
Switch running user to `Dockstore` a non superuser in order to allow row level security to work
(super users bypass security)
Existing migrations will continue running as postgres, future migrations should be dockstore compatible