### PR TITLE
Bump postgres to 10.10

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   postgres:
-    image: postgres:9.6.10
+    image: postgres:10.10
     restart: always
     volumes:
       - ./postgres-data:/var/lib/postgresql/data


### PR DESCRIPTION
Seems to deal with row level security performance issue.
Note that switching cannot be done with data in-place
It means a db_dump and psql -f (load)