### PR TITLE
Turn off Hibernate statistics

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -65,6 +65,16 @@ httpClient:
   maxConnectionsPerRoute: 1024
   keepAlive: 0ms
   retries: 0
+  
+logging:
+  appenders:
+    - type: console
+# this the default dropwizard (logstash) logFormat for reference      
+      #logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
+# this is a logFormat that replaces new lines in messages with a → 
+# TODO: should do the same with exceptions, but I couldn't figure it out
+      logFormat: "%-5p [%d{ISO8601,UTC}] %c: %replace(%msg){'[\\n]','→'}%n%rEx"
+
 
 database:
   # the name of your JDBC driver
@@ -85,7 +95,6 @@ database:
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     # create database as needed, disable in production
     hibernate.hbm2ddl.auto: validate
-    hibernate.generate_statistics: false
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -85,6 +85,7 @@ database:
     hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     # create database as needed, disable in production
     hibernate.hbm2ddl.auto: validate
+    hibernate.generate_statistics: false
 
   # the maximum amount of time to wait on an empty pool before throwing an exception
   maxWaitForConnection: 1s


### PR DESCRIPTION
dockstore/dockstore#2792

Output now looks like
```
INFO  [2019-10-30 21:48:31,820] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {→    89531 nanoseconds spent acquiring 2 JDBC connections;→    71644 nanoseconds spent releasing 2 JDBC connections;→    13512377 nanoseconds spent preparing 22 JDBC statements;→    17495305 nanoseconds spent executing 22 JDBC statements;→    0 nanoseconds spent executing 0 JDBC batches;→    0 nanoseconds spent performing 0 L2C puts;→    0 nanoseconds spent performing 0 L2C hits;→    0 nanoseconds spent performing 0 L2C misses;→    945165 nanoseconds spent executing 1 flushes (flushing a total of 3 entities and 3 collections);→    5672544 nanoseconds spent executing 2 partial-flushes (flushing a total of 3 entities and 3 collections)→}
10.11.8.80 - - [30/Oct./2019:21:48:31 +0000] "GET /containers/published?limit=1&sortCol=stars&sortOrder=desc HTTP/1.1" 200 3048 "http://odl-dyuen2.res.oicr.on.ca:8080/static/swagger-ui/index.html" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.70 Safari/537.36" 548
```

There's a multi_line_start_pattern configured at the agent layer to recognize → , but requires more work https://forums.aws.amazon.com/thread.jspa?threadID=158643
