### PR TITLE
Fix broken migrations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     volumes:
       - log_volume:/dockstore_logs
       - ./config/web.yml:/home/web.yml
-    command: ["dockerize", "-wait", "tcp://postgres:5432", "-timeout", "60s", "./home/init_migration.sh"]
+    command: ["dockerize", "-wait", "tcp://postgres:5432", "-timeout", "60s", "/home/init_migration.sh"]
     logging:
       driver: "awslogs"
       options:


### PR DESCRIPTION
I introduced this bug with the hotfix to move the JAR. It means migrations fails to run correctly on hotfix branch.

OTOH, no migrations were introduced in 1.7.2, so not sure if we should add it to the hotfix or not.

Not assigning to myself since I will be on vacation, to let somebody else merge it.