### PR TITLE
Change table owner to dockstore for 1.8.0

### DIFF
--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 {{#DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 {{^DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0,1.8.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password=postgres -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
+java -Ddw.database.user=dockstore -Ddw.database.password=dockstore -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0 | tee --append /dockstore_logs/webservice.out


### PR DESCRIPTION
Wasn't really able to get docker-compose working fully working locally, but did see that the table owners are set to dockstore in the postgres container. Can see if this fix works on staging?