### PR TITLE
Upgrade to postgres 11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,14 @@ version: '2'
 
 services:
   postgres:
-    image: postgres:10.10
+    image: postgres:11.6
     restart: always
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
     expose: 
       - "5432"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     logging:
       driver: "awslogs"
       options:


### PR DESCRIPTION
dockstore/dockstore#2321

Regarding environment variable:

https://www.postgresql.org/docs/current/auth-trust.html

Chose 11.6 over 11.7, the latest, because CircleCI is a little behind on the Postgres image we use.