### PR TITLE
Expose postgres port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     restart: always
     volumes:
       - ./postgres-data:/var/lib/postgresql/data
-    expose: 
-      - "5432"
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - ./postgres-data:/var/lib/postgresql/data
     expose: 
       - "5432"
+    ports:
+      - "5432:5432"
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
     logging:


### PR DESCRIPTION
For [SEAB-1018](https://ucsc-cgl.atlassian.net/browse/SEAB-1018)

Expose postgres port so Grafana can connect to the postgres database and use it as a datasource.

This PR is related to the following PR in dockstore-deploy where the security group is setup so only Grafana has access to the postgres database via this port: https://github.com/dockstore/dockstore-deploy/pull/28