### PR TITLE
Add Expect-CT header to nginx config template

### DIFF
--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -23,7 +23,7 @@ add_header X-Frame-Options DENY;
 
 # Certificate Transparency is a way of cross-referencing certificates with a log of all certificates issued,
 # to make sure they are authentic. This will become obsolete in June 2021.
-Expect-CT: enforce, max-age=604800;
+add_header Expect-CT 'enforce, max-age=604800';
 
 # nginx caches ips on startup, so doesn't survive webservice restarts
 # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -21,6 +21,10 @@ server_tokens off;
 # Don't allow page to be rendered inside a frame or iframe
 add_header X-Frame-Options DENY;
 
+# Certificate Transparency is a way of cross-referencing certificates with a log of all certificates issued,
+# to make sure they are authentic. This will become obsolete in June 2021.
+Expect-CT: enforce, max-age=30
+
 # nginx caches ips on startup, so doesn't survive webservice restarts
 # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/
 # https://stackoverflow.com/questions/46660436/nginx-does-not-automatically-pick-up-dns-changes-in-swarm/46664433#46664433

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -23,7 +23,7 @@ add_header X-Frame-Options DENY;
 
 # Certificate Transparency is a way of cross-referencing certificates with a log of all certificates issued,
 # to make sure they are authentic. This will become obsolete in June 2021.
-Expect-CT: enforce, max-age=30
+Expect-CT: enforce, max-age=604800;
 
 # nginx caches ips on startup, so doesn't survive webservice restarts
 # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/


### PR DESCRIPTION
This PR adds an Expect-CT header to the nginx config file template. The Expect-CT header is part of certificate transparency checking - comparing SSL certificates presented by websites and cross-checking them against a log of all certificates issued.

We leave out the `report-uri` parameter so we don't need to set up additional reporting infrastructure, additional domains, etc. This can be amended to include a reporting uri if we decide we want to do that.

See further discussion/comments in Jira ticket [SEAB-1199](https://ucsc-cgl.atlassian.net/browse/SEAB-1199).