### PR TITLE
add custom logger format for hibernate session metrics

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -70,6 +70,15 @@ httpClient:
   retries: 0
   
 logging:
+  loggers:
+    #customize logging for hibernate session metrics
+    "org.hibernate.engine.internal.StatisticalLoggingSessionEventListener":
+      # false = don't create new log event, but override existing
+      additive: false
+      appenders:
+        - type: console
+          logFormat: "%-5p [%d{ISO8601,UTC}] %c\t %replace(%replace(%msg){'[\\n{};]',''}){'([A-Za-z]) ([A-Za-z])','$1_$2'}%n%rEx"
+  #logging for other dropwizard things
   appenders:
     - type: console
 # this the default dropwizard (logstash) logFormat for reference      


### PR DESCRIPTION
Changed the format of the logger for hibernate session metrics. This will make it easier to parse the log and create filters/alarms on cloudwatch. All other logging should stay the same. 

New:
```
INFO  [2020-06-17 22:54:29,494] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener	 Session_Metrics     715973 nanoseconds_spent_acquiring 2 JDBC_connections    41910 nanoseconds_spent_releasing 2 JDBC_connections    14369035 nanoseconds_spent_preparing 28 JDBC_statements    33438171 nanoseconds_spent_executing 28 JDBC_statements    0 nanoseconds_spent_executing 0 JDBC_batches    0 nanoseconds_spent_performing 0 L2C_puts    0 nanoseconds_spent_performing 0 L2C_hits    0 nanoseconds_spent_performing 0 L2C_misses    0 nanoseconds_spent_executing 0 flushes (flushing_a total_of 0 entities_and 0 collections)    35432 nanoseconds_spent_executing 1 partial-flushes (flushing_a total_of 0 entities_and 0 collections)
```

Old :
```
INFO  [2020-06-17 23:06:49,584] org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: Session Metrics {→    713043 nanoseconds spent acquiring 2 JDBC connections;→    45382 nanoseconds spent releasing 2 JDBC connections;→    14685713 nanoseconds spent preparing 28 JDBC statements;→    41653704 nanoseconds spent executing 28 JDBC statements;→    0 nanoseconds spent executing 0 JDBC batches;→    0 nanoseconds spent performing 0 L2C puts;→    0 nanoseconds spent performing 0 L2C hits;→    0 nanoseconds spent performing 0 L2C misses;→    0 nanoseconds spent executing 0 flushes (flushing a total of 0 entities and 0 collections);→    30726 nanoseconds spent executing 1 partial-flushes (flushing a total of 0 entities and 0 collections)→}
```

Useful documentation for future reference:
https://www.dropwizard.io/en/latest/manual/configuration.html#logging
http://logback.qos.ch/manual/layouts.html#replace
https://www3.ntu.edu.sg/home/ehchua/programming/howto/Regexe.html