### PR TITLE
Move security headers into separate file, and fix include location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 - travis_wait 30 bash install_bootstrap --script
 - docker-compose version
 # validate the nginx configuration files using nginx via docker
-- docker run -v $PWD/config/default.nginx_http.conf:/etc/nginx/conf.d/default.conf:ro -v $PWD/config/default.nginx_http.shared.conf:/etc/nginx/conf.d/default.nginx_http.shared.conf:ro nginx:1.13.1 nginx -t -c /etc/nginx/nginx.conf
+- docker run -v $PWD/config/default.nginx_http.conf:/etc/nginx/conf.d/default.conf:ro -v $PWD/config/default.nginx_http.shared.conf:/etc/nginx/conf.d/default.nginx_http.shared.conf:ro -v $PWD/config/default.nginx_http.security.conf:/etc/nginx/conf.d/default.nginx_http.security.conf:ro nginx:1.13.1 nginx -t -c /etc/nginx/nginx.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
     volumes:
       - ./config/default.nginx_http.conf:/etc/nginx/conf.d/default.conf:ro
       - ./config/default.nginx_http.shared.conf:/etc/nginx/conf.d/default.nginx_http.shared.conf:ro
+      - ./config/default.nginx_http.security.conf:/etc/nginx/conf.d/default.nginx_http.security.conf:ro
     logging:
       driver: "awslogs"
       options:

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -73,6 +73,7 @@ function template()
     mustache dockstore_launcher_config/compose.config templates/web.yml.template > config/web.yml
     mustache dockstore_launcher_config/compose.config templates/default.nginx_http.conf.template > config/default.nginx_http.conf
     mustache dockstore_launcher_config/compose.config templates/default.nginx_http.shared.conf.template > config/default.nginx_http.shared.conf
+    mustache dockstore_launcher_config/compose.config templates/default.nginx_http.security.conf.template > config/default.nginx_http.security.conf
 
     mustache dockstore_launcher_config/compose.config templates/init_webservice.sh.template > config/init_webservice.sh
     mustache dockstore_launcher_config/compose.config templates/init_migration.sh.template > config/init_migration.sh

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -15,31 +15,6 @@ log_format  custom  '$http_x_forwarded_for - $remote_user [$time_local] "$reques
 # workaround for the way we're including conf https://serverfault.com/questions/729128/overriding-nginx-access-log-directive-duplicate-log-entries
 access_log  off;
 
-# Don't send nginx version number
-server_tokens off;
-
-# Don't allow page to be rendered inside a frame or iframe
-add_header X-Frame-Options DENY;
-
-# Certificate Transparency is a way of cross-referencing certificates with a log of all certificates issued,
-# to make sure they are authentic. This will become obsolete in June 2021.
-add_header Expect-CT 'enforce, max-age=604800';
-
-# Enable cross-site scripting filter (XSS)
-# (handled by the browser; usually enabled by default,
-# this header will re-enable the filter if disabled by user.)
-add_header X-XSS-Protection "1; mode=block";
-
-# Explicitly list domains allowed to serve content for this site
-add_header Content-Security-Policy-Report-Only "report-uri https://dockstore-security.org/csp-report;";
-add_header Content-Security-Policy-Report-Only "default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";
-add_header Content-Security-Policy-Report-Only "script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com;";
-add_header Content-Security-Policy-Report-Only "style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org;";
-add_header Content-Security-Policy-Report-Only "connect-src 'self' https://s3.amazonaws.com https://api.github.com https://view.commonwl.org;";
-add_header Content-Security-Policy-Report-Only "font-src 'self' https://fonts.gstatic.com https://gui.dockstore.org;";
-add_header Content-Security-Policy-Report-Only "frame-src 'self' https://discuss.dockstore.org;";
-add_header Content-Security-Policy-Report-Only "img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars3.githubusercontent.com https://camo.githubusercontent.com https://gui.dockstore.org https://i.imgur.com https://img.shields.io https://quay.io https://via.placeholder.com https://www.googletagmanager.com https://www.gravatar.com;";
-
 # nginx caches ips on startup, so doesn't survive webservice restarts
 # https://www.nginx.com/blog/dns-service-discovery-nginx-plus/
 # https://stackoverflow.com/questions/46660436/nginx-does-not-automatically-pick-up-dns-changes-in-swarm/46664433#46664433
@@ -49,6 +24,7 @@ server {
     set $webservice "webservice";
     server_name  default_server;
     include /etc/nginx/conf.d/default.nginx_http.shared.conf;
+    include /etc/nginx/conf.d/default.nginx_http.security.conf;
     access_log  /var/log/nginx/access.log  custom;
     # listen       4200 http2;
     # http2 not working over http for me
@@ -126,6 +102,7 @@ server {
     set $webservice "webservice";
     server_name  default_server;
     include /etc/nginx/conf.d/default.nginx_http.shared.conf;
+    include /etc/nginx/conf.d/default.nginx_http.security.conf;
     access_log  /var/log/nginx/access.log  custom;
     listen 8080;
 

--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -1,0 +1,24 @@
+# Don't send nginx version number
+server_tokens off;
+
+# Don't allow page to be rendered inside a frame or iframe
+add_header X-Frame-Options DENY;
+
+# Certificate Transparency is a way of cross-referencing certificates with a log of all certificates issued,
+# to make sure they are authentic. This will become obsolete in June 2021.
+add_header Expect-CT 'enforce, max-age=604800';
+
+# Enable cross-site scripting filter (XSS)
+# (handled by the browser; usually enabled by default,
+# this header will re-enable the filter if disabled by user.)
+add_header X-XSS-Protection "1; mode=block";
+
+# Explicitly list domains allowed to serve content for this site
+add_header Content-Security-Policy-Report-Only "report-uri https://dockstore-security.org/csp-report;";
+add_header Content-Security-Policy-Report-Only "default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";
+add_header Content-Security-Policy-Report-Only "script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com;";
+add_header Content-Security-Policy-Report-Only "style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org;";
+add_header Content-Security-Policy-Report-Only "connect-src 'self' https://s3.amazonaws.com https://api.github.com https://view.commonwl.org;";
+add_header Content-Security-Policy-Report-Only "font-src 'self' https://fonts.gstatic.com https://gui.dockstore.org;";
+add_header Content-Security-Policy-Report-Only "frame-src 'self' https://discuss.dockstore.org;";
+add_header Content-Security-Policy-Report-Only "img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars3.githubusercontent.com https://camo.githubusercontent.com https://gui.dockstore.org https://i.imgur.com https://img.shields.io https://quay.io https://via.placeholder.com https://www.googletagmanager.com https://www.gravatar.com;";


### PR DESCRIPTION
This PR moves the security headers into a separate include file, and fixes the location from which the security headers are being included (before they were outside the server blocks, and therefore being ignored; now they are included from inside the server blocks).