### PR TITLE
Fix dockstore-security.org CSP reporting URL

### DIFF
--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -14,7 +14,7 @@ add_header Expect-CT 'enforce, max-age=604800';
 add_header X-XSS-Protection "1; mode=block";
 
 # Explicitly list domains allowed to serve content for this site
-add_header Content-Security-Policy-Report-Only "report-uri https://dockstore-security.org/csp-report;";
+add_header Content-Security-Policy-Report-Only "report-uri https://api.dockstore-security.org/csp-report;";
 add_header Content-Security-Policy-Report-Only "default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";
 add_header Content-Security-Policy-Report-Only "script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com;";
 add_header Content-Security-Policy-Report-Only "style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org;";


### PR DESCRIPTION
This fixes the reporting URL for Dockstore CSP reports.

The URL is now api.dockstore-security.org (before it was just dockstore-security.org)