### PR TITLE
Add an nginx Referrer-Policy header

### DIFF
--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -13,6 +13,10 @@ add_header Expect-CT 'enforce, max-age=604800';
 # this header will re-enable the filter if disabled by user.)
 add_header X-XSS-Protection "1; mode=block";
 
+# Enable a referrer policy that protects users' privacy while still enabling
+# Dockstore to see how users interact with the site.
+add_header Referrer-Policy "same-origin";
+
 # Explicitly list domains allowed to serve content for this site
 add_header Content-Security-Policy-Report-Only "report-uri https://api.dockstore-security.org/csp-report;";
 add_header Content-Security-Policy-Report-Only "default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";


### PR DESCRIPTION
This PR adds a Referrer-Policy header to the nginx configuration file. The Referrer-Policy header specifies whether and how to send a header along with users when they leave dockstore.org that tells other sites what URL the user came from. The value specified (same-origin) will include the header specifying where the user came from _only_ if they visit another site at the dockstore.org domain. If the user visits any other site the headers will not be included.