### PR TITLE
Fix CSP header to be a single header

### DIFF
--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -18,12 +18,4 @@ add_header X-XSS-Protection "1; mode=block";
 add_header Referrer-Policy "same-origin";
 
 # Explicitly list domains allowed to serve content for this site
-set $CSP "report-uri https://api.dockstore-security.org/csp-report;";
-set $CSP "${CSP}; default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";
-set $CSP "${CSP}; script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com;";
-set $CSP "${CSP}; style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org;";
-set $CSP "${CSP}; connect-src 'self' https://s3.amazonaws.com https://api.github.com https://view.commonwl.org;";
-set $CSP "${CSP}; font-src 'self' https://fonts.gstatic.com https://gui.dockstore.org;";
-set $CSP "${CSP}; frame-src 'self' https://discuss.dockstore.org;";
-set $CSP "${CSP}; img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars3.githubusercontent.com https://camo.githubusercontent.com https://gui.dockstore.org https://i.imgur.com https://img.shields.io https://quay.io https://via.placeholder.com https://www.googletagmanager.com https://www.gravatar.com;";
-add_header Content-Security-Policy-Report-Only $CSP;
+add_header Content-Security-Policy-Report-Only "report-uri https://api.dockstore-security.org/csp-report; default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none'; script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com; style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org; connect-src 'self' https://s3.amazonaws.com https://api.github.com https://view.commonwl.org; font-src 'self' https://fonts.gstatic.com https://gui.dockstore.org; frame-src 'self' https://discuss.dockstore.org; img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars3.githubusercontent.com https://camo.githubusercontent.com https://gui.dockstore.org https://i.imgur.com https://img.shields.io https://quay.io https://via.placeholder.com https://www.googletagmanager.com https://www.gravatar.com;";

--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -18,11 +18,12 @@ add_header X-XSS-Protection "1; mode=block";
 add_header Referrer-Policy "same-origin";
 
 # Explicitly list domains allowed to serve content for this site
-add_header Content-Security-Policy-Report-Only "report-uri https://api.dockstore-security.org/csp-report;";
-add_header Content-Security-Policy-Report-Only "default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";
-add_header Content-Security-Policy-Report-Only "script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com;";
-add_header Content-Security-Policy-Report-Only "style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org;";
-add_header Content-Security-Policy-Report-Only "connect-src 'self' https://s3.amazonaws.com https://api.github.com https://view.commonwl.org;";
-add_header Content-Security-Policy-Report-Only "font-src 'self' https://fonts.gstatic.com https://gui.dockstore.org;";
-add_header Content-Security-Policy-Report-Only "frame-src 'self' https://discuss.dockstore.org;";
-add_header Content-Security-Policy-Report-Only "img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars3.githubusercontent.com https://camo.githubusercontent.com https://gui.dockstore.org https://i.imgur.com https://img.shields.io https://quay.io https://via.placeholder.com https://www.googletagmanager.com https://www.gravatar.com;";
+set $CSP "report-uri https://api.dockstore-security.org/csp-report;";
+set $CSP "${CSP}; default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none';";
+set $CSP "${CSP}; script-src 'report-sample' 'self' https://discuss.dockstore.org https://gui.dockstore.org https://platform.twitter.com https://www.google-analytics.com https://www.googletagmanager.com;";
+set $CSP "${CSP}; style-src 'report-sample' 'self' https://cdnjs.cloudflare.com https://fonts.googleapis.com https://gui.dockstore.org;";
+set $CSP "${CSP}; connect-src 'self' https://s3.amazonaws.com https://api.github.com https://view.commonwl.org;";
+set $CSP "${CSP}; font-src 'self' https://fonts.gstatic.com https://gui.dockstore.org;";
+set $CSP "${CSP}; frame-src 'self' https://discuss.dockstore.org;";
+set $CSP "${CSP}; img-src 'self' data: https://avatars0.githubusercontent.com https://avatars1.githubusercontent.com https://avatars3.githubusercontent.com https://camo.githubusercontent.com https://gui.dockstore.org https://i.imgur.com https://img.shields.io https://quay.io https://via.placeholder.com https://www.googletagmanager.com https://www.gravatar.com;";
+add_header Content-Security-Policy-Report-Only $CSP;


### PR DESCRIPTION
The Content-Seucrity-Policy header was originally broken up into multiple headers to simplify management of the CSP. However, if the CSP is implemented as multiple headers, they should be listed in order of increasing strictness, whereas we implemented them in random order. To fix this, we make the CSP header a one-liner. (Tried using an nginx variable, but that failed to validate in the Travis tests.)

Jira ticket: [SEAB-1530](https://ucsc-cgl.atlassian.net/browse/SEAB-1530) and [SEAB-261](https://ucsc-cgl.atlassian.net/browse/SEAB-261)