### PR TITLE
Serve HSTS header

### DIFF
--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -10,7 +10,7 @@ map $sent_http_content_type $expires {
 # Only set Strict-Transport-Security for https requests
 map $http_x_forwarded_proto $hsts_header {
   default '';
-  https "max-age=31536000; includeSubDomains preload";
+  https max-age=31536000; includeSubDomains preload;
 }
 
 # https://aws.amazon.com/premiumsupport/knowledge-center/elb-capture-client-ip-addresses/

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -10,7 +10,7 @@ map $sent_http_content_type $expires {
 # Only set Strict-Transport-Security for https requests
 map $http_x_forwarded_proto $hsts_header {
   default '';
-  https "max-age=31536000; includeSubDomains; preload;"
+  https "max-age=31536000; includeSubDomains; preload;";
 }
 
 # https://aws.amazon.com/premiumsupport/knowledge-center/elb-capture-client-ip-addresses/

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -7,6 +7,11 @@ map $sent_http_content_type $expires {
     application/octet-stream   604800;
     ~image/                    604800;
 }
+# Only set Strict-Transport-Security for https requests
+map $http_x_forwarded_proto $hsts_header {
+  default '';
+  https Strict-Transport-Security "max-age=31536000; includeSubDomains preload"";
+}
 
 # https://aws.amazon.com/premiumsupport/knowledge-center/elb-capture-client-ip-addresses/
 log_format  custom  '$http_x_forwarded_for - $remote_user [$time_local] "$request" '
@@ -46,8 +51,6 @@ server {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon application/javascript;
 
     expires $expires;
-
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     # used to redirect swagger.json as retrieved by swagger ui without changes
     location = /swagger.json {

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -10,7 +10,7 @@ map $sent_http_content_type $expires {
 # Only set Strict-Transport-Security for https requests
 map $http_x_forwarded_proto $hsts_header {
   default '';
-  https Strict-Transport-Security "max-age=31536000; includeSubDomains preload"";
+  https "max-age=31536000; includeSubDomains preload"";
 }
 
 # https://aws.amazon.com/premiumsupport/knowledge-center/elb-capture-client-ip-addresses/

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -10,7 +10,7 @@ map $sent_http_content_type $expires {
 # Only set Strict-Transport-Security for https requests
 map $http_x_forwarded_proto $hsts_header {
   default '';
-  https "max-age=31536000; includeSubDomains preload"";
+  https "max-age=31536000; includeSubDomains preload";
 }
 
 # https://aws.amazon.com/premiumsupport/knowledge-center/elb-capture-client-ip-addresses/

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -10,7 +10,7 @@ map $sent_http_content_type $expires {
 # Only set Strict-Transport-Security for https requests
 map $http_x_forwarded_proto $hsts_header {
   default '';
-  https max-age=31536000; includeSubDomains preload;
+  https "max-age=31536000; includeSubDomains; preload;"
 }
 
 # https://aws.amazon.com/premiumsupport/knowledge-center/elb-capture-client-ip-addresses/

--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -25,3 +25,5 @@ proxy_hide_header Server;
 
 # Protect against MIME sniffing
 add_header X-Content-Type-Options "nosniff";
+
+add_header Strict-Transport-Security $hsts_header

--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -26,4 +26,4 @@ proxy_hide_header Server;
 # Protect against MIME sniffing
 add_header X-Content-Type-Options "nosniff";
 
-add_header Strict-Transport-Security $hsts_header
+add_header Strict-Transport-Security $hsts_header;


### PR DESCRIPTION

https://ucsc-cgl.atlassian.net/browse/SEAB-1062

It was already there, but

1. Was missing preload
2. Per RFC, we should only set it for HTTPS -- look at X-Forwarded-Proto
3. Moved updated version to security template (can't have the
map in there though)