### PR TITLE
remove deprecated script settings

### DIFF
--- a/templates/elasticsearch.yml
+++ b/templates/elasticsearch.yml
@@ -5,13 +5,8 @@ http.max_content_length: 1000mb
 # Uncomment the following lines for a production cluster deployment
 #transport.host: 0.0.0.0
 #discovery.zen.minimum_master_nodes: 1
-# the following seem broken
 script.allowed_types: none
 script.allowed_contexts: none
-script.inline: false  
-script.stored: false  
-script.file:   false
-script.update: false
 
 rest.action.multi.allow_explicit_index: true
 # default off, not idea, but matches elastic search 5.


### PR DESCRIPTION
looks like in ES 6.x the only script settings are `script.allowed_types:` and `script.allowed_context` as per [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/modules-scripting-security.html) and [here](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html#breaking_60_scripting_changes) Based on previous settings looks like we don't want scripts anywhere so both would be set to `none`