### PR TITLE
update jvm options

### DIFF
--- a/templates/jvm.options.dockstore.es.template
+++ b/templates/jvm.options.dockstore.es.template
@@ -33,9 +33,9 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## optimizations
 

--- a/templates/jvm.options.es.template
+++ b/templates/jvm.options.es.template
@@ -34,9 +34,9 @@
 ################################################################
 
 ## GC configuration
--XX:+UseConcMarkSweepGC
--XX:CMSInitiatingOccupancyFraction=75
--XX:+UseCMSInitiatingOccupancyOnly
+8-13:-XX:+UseConcMarkSweepGC
+8-13:-XX:CMSInitiatingOccupancyFraction=75
+8-13:-XX:+UseCMSInitiatingOccupancyOnly
 
 ## optimizations
 

--- a/templates/jvm.options.es.template
+++ b/templates/jvm.options.es.template
@@ -34,9 +34,9 @@
 ################################################################
 
 ## GC configuration
-8-13:-XX:+UseConcMarkSweepGC
-8-13:-XX:CMSInitiatingOccupancyFraction=75
-8-13:-XX:+UseCMSInitiatingOccupancyOnly
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
 
 ## optimizations
 


### PR DESCRIPTION
- Elasticsearch failing with `Unrecognized VM option 'UseConcMarkSweepGC'`, looks like an issue with needing to update jvm options. 
- Made the changes recommended [here](https://github.com/elastic/elasticsearch/issues/51361)
- should probably test this first though