### PR TITLE
add quotes to avoid interpreting versions as numbers

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -182,5 +182,5 @@ uiConfig:
   documentationUrl: {{ DOCUMENTATION_URL }}
   featuredContentUrl: {{ FEATURED_CONTENT_URL }}
 
-  composeSetupVersion: {{ COMPOSE_SETUP_VERSION }}
-  deployVersion: {{ DEPLOY_VERSION }}
+  composeSetupVersion: "{{ COMPOSE_SETUP_VERSION }}"
+  deployVersion: "{{ DEPLOY_VERSION }}"


### PR DESCRIPTION
Main issue: https://github.com/dockstore/dockstore/issues/3962

`dockstore-deploy` and `compose_setup` were tagged as `1.10` instead of `1.10.0` causing them to be interpreted as decimal numbers and displayed as `1.1`.