### PR TITLE
Handle ampersand values

### DIFF
--- a/install_bootstrap
+++ b/install_bootstrap
@@ -247,7 +247,7 @@ done
 
 #Read the config file if it exists and then show previous values (but do not override variables in this script)
 if [ -f dockstore_launcher_config/compose.config ] ; then
-    source <(jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" dockstore_launcher_config/compose.config | grep -v "CONSONANCE")
+    source <(jq -r 'to_entries|map("\(.key)=\"\(.value|tostring)\"")|.[]' dockstore_launcher_config/compose.config | grep -v "CONSONANCE")
 fi
 
 while [[ "${run_dockstore_launcher^^}" != 'Y' &&  "${run_dockstore_launcher^^}" != 'N' && "$@" != *"--script"* ]] ; do

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -4,12 +4,12 @@
 cd "$(dirname "$0")"
 
 {{#DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password={{{ POSTGRES_DBPASSWORD }}} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 {{^DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password={{{ POSTGRES_DBPASSWORD }}} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 # this particular migration needs to run as postgres because only postgres can surrender ownership
-java -Ddw.database.user=postgres -Ddw.database.password={{{ POSTGRES_DBPASSWORD }}} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
+java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
 java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0 | tee --append /dockstore_logs/webservice.out

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -12,4 +12,4 @@ java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0 | tee --append /dockstore_logs/webservice.out

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -4,12 +4,12 @@
 cd "$(dirname "$0")"
 
 {{#DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password={{ POSTGRES_DBPASSWORD }} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password={{{ POSTGRES_DBPASSWORD }}} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 {{^DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password={{ POSTGRES_DBPASSWORD }} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password={{{ POSTGRES_DBPASSWORD }}} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
 {{/DATABASE_GENERATED}}
 # this particular migration needs to run as postgres because only postgres can surrender ownership
-java -Ddw.database.user=postgres -Ddw.database.password={{ POSTGRES_DBPASSWORD }} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
+java -Ddw.database.user=postgres -Ddw.database.password={{{ POSTGRES_DBPASSWORD }}} -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{ DOCKSTORE_DBPASSWORD }}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0 | tee --append /dockstore_logs/webservice.out


### PR DESCRIPTION
An ampersand in a password was causing deploy to dev to fail.

dockstore/dockstore#3971

1. The code in install_bootstrap converts a JSON file to bash variable assignments. The values weren't quoted, so an ampersand would break and cause a syntax error
2. Same thing in init_migrations.sh

Fix is to quote the values.

In testing, noticed that 1.11 migrations had not been added