### PR TITLE
Escape DOCKSTORE_DBPASSWORD mustache variable in web.yml template

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -96,7 +96,7 @@ database:
   user: dockstore
 
   # the password
-  password: {{ DOCKSTORE_DBPASSWORD }}
+  password: {{{ DOCKSTORE_DBPASSWORD }}}
 
   # the JDBC URL
   url: jdbc:postgresql://{{ DATABASE_DOMAIN }}:5432/postgres


### PR DESCRIPTION
PR #176 used triple mustaches to escape ampersands in the db password variables, but missed one. This PR fixes the one missed.

Relates to #176 and dockstore/dockstore#3971 