### PR TITLE
Support digest for the web service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   migration: 
-    image: quay.io/dockstore/dockstore-webservice:${DOCKSTORE_VERSION}
+    image: quay.io/dockstore/dockstore-webservice${DOCKSTORE_VERSION}
     volumes:
       - log_volume:/dockstore_logs
       - ./config/web.yml:/home/web.yml
@@ -16,7 +16,7 @@ services:
         awslogs-stream: "migration"
 
   webservice: 
-    image: quay.io/dockstore/dockstore-webservice:${DOCKSTORE_VERSION}
+    image: quay.io/dockstore/dockstore-webservice${DOCKSTORE_VERSION}
     restart: always
     depends_on:
       - migration

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -12,4 +12,4 @@ java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0 | tee --append /dockstore_logs/webservice.out


### PR DESCRIPTION
Digest is "...webservice@sha256:123..."; because we had the colon
hard-coded in there we couldn't specify it.

Note that for dev, where we don't need nor want the digest, we will need to specify
`:develop`.

Depends what we decide to do with #195. Created this just in case.

I think for 1.11, we should just manually verify...