### PR TITLE
Set referrer-policy to strict-origin

### DIFF
--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -15,7 +15,7 @@ add_header X-XSS-Protection "1; mode=block" always;
 
 # Enable a referrer policy that protects users' privacy while still enabling
 # Dockstore to see how users interact with the site.
-add_header Referrer-Policy "same-origin" always;
+add_header Referrer-Policy "strict-origin" always;
 
 # Explicitly list domains allowed to serve content for this site
 add_header Content-Security-Policy-Report-Only "report-uri https://api.dockstore-security.org/csp-report; default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none'; script-src 'report-sample' 'self' 'unsafe-hashes' 'unsafe-inline' 'unsafe-eval' discuss.dockstore.org gui.dockstore.org *.twitter.com *.twimg.com www.google-analytics.com www.googletagmanager.com; style-src 'report-sample' 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com *.twitter.com *.twimg.com gui.dockstore.org; connect-src 'self' s3.amazonaws.com api.github.com view.commonwl.org www.google-analytics.com gui.dockstore.org; font-src 'self' fonts.gstatic.com gui.dockstore.org; frame-src 'self' discuss.dockstore.org platform.twitter.com; img-src data: 'self' avatars0.githubusercontent.com avatars1.githubusercontent.com avatars2.githubusercontent.com avatars3.githubusercontent.com camo.githubusercontent.com gui.dockstore.org i.imgur.com api.travis-ci.com img.shields.io quay.io via.placeholder.com *.wp.com *.googleusercontent.com www.googletagmanager.com www.google-analytics.com www.gravatar.com *.twitter.com *.twimg.com;" always;

--- a/templates/default.nginx_http.security.conf.template
+++ b/templates/default.nginx_http.security.conf.template
@@ -15,7 +15,7 @@ add_header X-XSS-Protection "1; mode=block" always;
 
 # Enable a referrer policy that protects users' privacy while still enabling
 # Dockstore to see how users interact with the site.
-add_header Referrer-Policy "strict-origin" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
 # Explicitly list domains allowed to serve content for this site
 add_header Content-Security-Policy-Report-Only "report-uri https://api.dockstore-security.org/csp-report; default-src 'self'; object-src 'none'; base-uri 'self'; manifest-src 'self'; media-src 'self'; worker-src 'none'; script-src 'report-sample' 'self' 'unsafe-hashes' 'unsafe-inline' 'unsafe-eval' discuss.dockstore.org gui.dockstore.org *.twitter.com *.twimg.com www.google-analytics.com www.googletagmanager.com; style-src 'report-sample' 'self' 'unsafe-inline' cdnjs.cloudflare.com fonts.googleapis.com *.twitter.com *.twimg.com gui.dockstore.org; connect-src 'self' s3.amazonaws.com api.github.com view.commonwl.org www.google-analytics.com gui.dockstore.org; font-src 'self' fonts.gstatic.com gui.dockstore.org; frame-src 'self' discuss.dockstore.org platform.twitter.com; img-src data: 'self' avatars0.githubusercontent.com avatars1.githubusercontent.com avatars2.githubusercontent.com avatars3.githubusercontent.com camo.githubusercontent.com gui.dockstore.org i.imgur.com api.travis-ci.com img.shields.io quay.io via.placeholder.com *.wp.com *.googleusercontent.com www.googletagmanager.com www.google-analytics.com www.gravatar.com *.twitter.com *.twimg.com;" always;

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -12,4 +12,4 @@ java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0 | tee --append /dockstore_logs/webservice.out


### PR DESCRIPTION
dockstore/dockstore#4263

This will send the origin only (no path nor params),
and only if https. It's the minimum needed for Launch
w/Galaxy on Terra to work, and seems relative safe, although
this might trigger our scanner again.