### PR TITLE
Get target group health check working

### DIFF
--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -100,20 +100,20 @@ server {
     }
 }
 
+# Server block for access via IP instead of domain
 server {
     set $webservice "webservice";
+    access_log  /var/log/nginx/access.log  custom;
     listen 4200 default_server;
+
     if ($http_user_agent = "ELB-HealthChecker/2.0") {
-        rewrite ^(.*)$ /elbcheck/$1;
+        rewrite ^(.*)$ /elbcheck;
     }
     location / {
         return 301 https://{{ DOMAIN_NAME }}$request_uri;
     }
     location /elbcheck/ {
-        rewrite ^/elbcheck/(.*)$ $1;
-        rewrite ^ $request_uri;
-        rewrite ^/api/(.*) $1 break;
-        return 400;
-        proxy_pass     http://$webservice:8080/$uri;
+        # Send all ELB health checks to this endpoint
+        proxy_pass     http://$webservice:8080/metadata/sourceControlList;
     }
 }

--- a/templates/default.nginx_http.conf.template
+++ b/templates/default.nginx_http.conf.template
@@ -101,6 +101,19 @@ server {
 }
 
 server {
+    set $webservice "webservice";
     listen 4200 default_server;
-    return 301 https://{{ DOMAIN_NAME }}$request_uri;
+    if ($http_user_agent = "ELB-HealthChecker/2.0") {
+        rewrite ^(.*)$ /elbcheck/$1;
+    }
+    location / {
+        return 301 https://{{ DOMAIN_NAME }}$request_uri;
+    }
+    location /elbcheck/ {
+        rewrite ^/elbcheck/(.*)$ $1;
+        rewrite ^ $request_uri;
+        rewrite ^/api/(.*) $1 break;
+        return 400;
+        proxy_pass     http://$webservice:8080/$uri;
+    }
 }


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-3627

Problem: ELB target group checks health using IP; #211 redirects such requests.

Fix: If request comes from ELB, detected via user-agent, add `elbcheck` to the beginning of the request path, then in the `location /elbcheck` block, strip it back out. Because[ if is evil if used in location](https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/).

Lameness:

1. API location block duplicated from further up. If we go with this approach, I'll extract it into a file.
2. Forwarding all requests to API endpoint, even non-API ones. I should probably make like 112 be `/location/elbcheck/api`, but waiting for initial feedback.
3. Open to the world and people could spoof the user-agent. But that would just make the way it was before, which "only" affected Google search results (no backdoors or anything), so no harm done.
4. Not testing the exact same path that actual requests will use
5. Logging not turned on for this path (can add the directive though).
