### PR TITLE
Fix image digest to handle tags

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,1 +1,3 @@
 #initial .gitallowed, in the future this is where git-secrets false-positives should be added
+
+scripts/tests/test-webservice-image-digest.py:.*sha256

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,3 +39,7 @@ jobs:
       run: bash install_bootstrap --script
     - name: Run Docker image to validate nginx config
       run: docker run -v $PWD/config/default.nginx_http.conf:/etc/nginx/conf.d/default.conf:ro -v $PWD/config/default.nginx_http.shared.conf:/etc/nginx/conf.d/default.nginx_http.shared.conf:ro -v $PWD/config/default.nginx_http.security.conf:/etc/nginx/conf.d/default.nginx_http.security.conf:ro nginx:1.13.1 nginx -t -c /etc/nginx/nginx.conf
+    - name: Test image digest script
+      run: |
+        cd scripts/tests
+        python test-webservice-image-digest.py

--- a/scripts/tests/test-webservice-image-digest.py
+++ b/scripts/tests/test-webservice-image-digest.py
@@ -1,0 +1,43 @@
+"""
+
+Test the script webservice-image-digest by calling this from 
+the tests directory
+
+cd compose_setup/scripts/tests
+python test-webservice-image-digest.py
+
+"""
+
+import unittest
+
+import subprocess
+
+script_location = "../webservice-image-digest.py"
+
+base_command = "python {}".format(script_location)
+branch = "develop"
+simple_tag = "digest_test"
+annotated_tag = "1.12.0-beta.1"
+
+class TestDigest(unittest.TestCase):
+
+    def test_branch(self):
+        cmd = "{} {}".format(base_command, branch)
+        ret = subprocess.check_output(cmd, shell=True, universal_newlines=True).rstrip()
+        self.assertEqual(ret, "sha256:52cf6b09e89a238bfd1d98dd01139442d67fcaaa377c179f315dd06555f7bcae")
+        pass
+
+    def test_simple_tag(self):
+        cmd = "{} {}".format(base_command, simple_tag)
+        ret = subprocess.check_output(cmd, shell=True, universal_newlines=True).rstrip()
+        self.assertEqual(ret, "sha256:52cf6b09e89a238bfd1d98dd01139442d67fcaaa377c179f315dd06555f7bcae")
+        pass
+
+    def test_annotated_tag(self):
+        cmd = "{} {}".format(base_command, annotated_tag)
+        ret = subprocess.check_output(cmd, shell=True, universal_newlines=True).rstrip()
+        self.assertEqual(ret, "sha256:e6dcfdc9ea351b57cde556ff3c68f96b838e8e30cdb4ee693a29b6ef16f3a4be")
+        pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tests/test-webservice-image-digest.py
+++ b/scripts/tests/test-webservice-image-digest.py
@@ -30,7 +30,7 @@ class TestDigest(unittest.TestCase):
     def test_simple_tag(self):
         cmd = "{} {}".format(base_command, simple_tag)
         ret = subprocess.check_output(cmd, shell=True, universal_newlines=True).rstrip()
-        self.assertEqual(ret, "sha256:52cf6b09e89a238bfd1d98dd01139442d67fcaaa377c179f315dd06555f7bcae")
+        self.assertEqual(ret, "sha256:f21d00e9f01d54eb891c128fb88b76554cb0b47c775929dc05e39a03954e7b0b")
         pass
 
     def test_annotated_tag(self):

--- a/scripts/webservice-image-digest.py
+++ b/scripts/webservice-image-digest.py
@@ -32,7 +32,12 @@ def get_commit_from_github(tag_or_branch):
   tag_url = "{}/{}/{}".format(base_url, "git/ref/tags", tag_or_branch)
   response = requests.get(tag_url)
   if (response.status_code == 200):
-    return get_commit_from_tag_url(response.json()['object']['url'])
+    # simple tag
+    if (response.json()['object']['type'] == "commit"):
+      return response.json()['object']['sha']
+    else:
+      # annotated tag
+      return get_commit_from_tag_url(response.json()['object']['url'])
   # try branch
   branch_url = "{}/{}={}".format(base_url, "commits?sha", tag_or_branch)
   response = requests.get(branch_url)


### PR DESCRIPTION
Currently only works with branches. To work with tags, you must go look up the commit a tag references.

Also adds a slightly more useful error message when the digest isn't found.