### PR TITLE
Turn off a test that was incorrectly specified

### DIFF
--- a/scripts/tests/test-webservice-image-digest.py
+++ b/scripts/tests/test-webservice-image-digest.py
@@ -21,11 +21,12 @@ annotated_tag = "1.12.0-beta.1"
 
 class TestDigest(unittest.TestCase):
 
-    def test_branch(self):
-        cmd = "{} {}".format(base_command, branch)
-        ret = subprocess.check_output(cmd, shell=True, universal_newlines=True).rstrip()
-        self.assertEqual(ret, "sha256:52cf6b09e89a238bfd1d98dd01139442d67fcaaa377c179f315dd06555f7bcae")
-        pass
+# This test is turned off because there is no stable branch to test against
+#    def test_branch(self):
+#        cmd = "{} {}".format(base_command, branch)
+#        ret = subprocess.check_output(cmd, shell=True, universal_newlines=True).rstrip()
+#        self.assertEqual(ret, "sha256:52cf6b09e89a238bfd1d98dd01139442d67fcaaa377c179f315dd06555f7bcae")
+#        pass
 
     def test_simple_tag(self):
         cmd = "{} {}".format(base_command, simple_tag)


### PR DESCRIPTION
Cherry-pick of commit from PR #221 

CI builds were failing. 

Interestingly, I just noticed they failed on the PR for this hotfix, #226 as well as on the hotfix itself. Just looked, and passing builds are only required for develop and master. I added a `hotfix/*` branch protection rule (Denis, please double-check). So we (I) only noticed in when I merged to master.