### PR TITLE
Invalidate authentication cache more often

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -63,7 +63,7 @@ externalConfig:
   scheme: http{{#HTTPS}}s{{/HTTPS}}
   port:
 
-authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10m
+authenticationCachePolicy: maximumSize=10000, expireAfterAccess=10s
 
 httpClient:
   timeout: 5500ms


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-3895

Companion PRs:
- UI: https://github.com/dockstore/dockstore-ui2/pull/1573
- webservice: https://github.com/dockstore/dockstore/pull/5031

I recommend reviewing this PR first, then the UI PR, then the webservice PR for things to make the most sense.

This PR updates the `expireAfterAccess` property to 10 seconds. This is done so that the authentication cache is invalidated often enough that in a multiple webservice deployment, a deleted user's tokens would be invalidated in all webservices and they won't be able to call authenticated endpoints.