### PR TITLE
Remove webservice log file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
   migration: 
     image: quay.io/dockstore/dockstore-webservice@${DOCKSTORE_IMAGE_DIGEST}
     volumes:
-      - log_volume:/dockstore_logs
       - ./config/web.yml:/home/web.yml
       - ./config/init_migration.sh:/home/init_migration.sh
     command: ["bash", "/home/init_migration.sh"]
@@ -21,7 +20,6 @@ services:
     depends_on:
       - migration
     volumes:
-      - log_volume:/dockstore_logs
       - ./config/web.yml:/home/web.yml
       - ./config/init_webservice.sh:/home/init_webservice.sh
       - ${GITHUB_APP_PRIVATE_KEY_FILE}:/dockstore/github-key/dockstore-github-private-key.pem
@@ -75,6 +73,5 @@ services:
 #        awslogs-stream: "metricbeat"
 
 volumes:
-  log_volume: 
   esdata1:
     driver: local

--- a/dockstore_launcher_config/compose.config
+++ b/dockstore_launcher_config/compose.config
@@ -39,7 +39,7 @@
 "GOOGLE_CLIENT_ID":"potato",
 "GOOGLE_CLIENT_SECRET":"potato",
 "HTTPS":false,
-"IS_FARGATE_DEPLOY":false,
+"IS_FARGATE_DEPLOY":true,
 "LOGSTASH":false,
 "LOGSTASH_HOST":"replaceme",
 "NEXTFLOW_PARSING_LAMBDA_VERSION":"n/a",

--- a/dockstore_launcher_config/compose.config
+++ b/dockstore_launcher_config/compose.config
@@ -39,7 +39,7 @@
 "GOOGLE_CLIENT_ID":"potato",
 "GOOGLE_CLIENT_SECRET":"potato",
 "HTTPS":false,
-"IS_FARGATE_DEPLOY":true,
+"IS_FARGATE_DEPLOY":false,
 "LOGSTASH":false,
 "LOGSTASH_HOST":"replaceme",
 "NEXTFLOW_PARSING_LAMBDA_VERSION":"n/a",

--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -4,12 +4,12 @@
 cd "$(dirname "$0")"
 
 {{#DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.3.0.generated,1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0
 {{/DATABASE_GENERATED}}
 {{^DATABASE_GENERATED}}
-java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.3.1.consistency,1.4.0,1.5.0,1.6.0,1.7.0
 {{/DATABASE_GENERATED}}
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0 | tee --append /dockstore_logs/webservice.out
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0

--- a/templates/init_webservice.sh.template
+++ b/templates/init_webservice.sh.template
@@ -2,6 +2,6 @@
 
 cd "$(dirname "$0")"
 
-java -XX:MaxRAMPercentage=50.0 -XX:+ExitOnOutOfMemoryError -jar /home/dockstore-webservice-*.jar server web.yml | tee --append /dockstore_logs/webservice.out
+java -XX:MaxRAMPercentage=50.0 -XX:+ExitOnOutOfMemoryError -jar /home/dockstore-webservice-*.jar server web.yml
 
 


### PR DESCRIPTION
**Description**
This PR removes the `webservice.out` log file and the associated docker volume. The container logs are being sent to AWS CloudWatch using the awslogs driver so this file is redundant and takes up disk space. View this [ticket comment](https://ucsc-cgl.atlassian.net/browse/SEAB-4810?focusedCommentId=43364) for more information about the log file growth investigation.

**Review Instructions**
Verify that the container logs are still being sent to CloudWatch. Will have to wait for a hotfix deploy to staging to verify.

**Issue**
[SEAB-4810](https://ucsc-cgl.atlassian.net/browse/SEAB-4810)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
