### PR TITLE
SEAB-4880: Include galaxy plugin in webservice docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       - ./config/web.yml:/home/web.yml
       - ./config/init_webservice.sh:/home/init_webservice.sh
       - ${GITHUB_APP_PRIVATE_KEY_FILE}:/dockstore/github-key/dockstore-github-private-key.pem
-      - ../language-plugins/:/root/.dockstore/language-plugins
     command: ["bash", "/home/init_webservice.sh"]
     ports:
       - "8081:8081"

--- a/install_bootstrap
+++ b/install_bootstrap
@@ -66,26 +66,12 @@ function template()
     for f in $(ls templates/rules/); do mustache dockstore_launcher_config/compose.config templates/rules/$f > config/rules/$f; done
 }
 
-# Delete any galaxy plugin versions already in folder and download if a version has been specified.
-function download_galaxy()
-{
-    if [ ! -d "../language-plugins" ] ; then
-        mkdir ../language-plugins
-    fi
-
-    find ../language-plugins -regextype posix-extended -regex '.*dockstore-galaxy-interface.*' -delete
-    wget -nc -P ../language-plugins/ https://artifacts.oicr.on.ca/artifactory/collab-release/com/github/galaxyproject/dockstore-galaxy-interface/dockstore-galaxy-interface/${GALAXY_PLUGIN_VERSION}/dockstore-galaxy-interface-${GALAXY_PLUGIN_VERSION}.jar
-
-}
-
 #Read the config file if it exists
 if [ -f dockstore_launcher_config/compose.config ] ; then
     source <(jq -r 'to_entries|map("\(.key)=\"\(.value|tostring)\"")|.[]' dockstore_launcher_config/compose.config)
 fi
 
 template
-
-download_galaxy "$*"
 
 if [ $IS_FARGATE_DEPLOY == "false" ]; then
     # We need to set the environment variable for the image digest

--- a/scripts/webservice-image-digest.py
+++ b/scripts/webservice-image-digest.py
@@ -58,7 +58,7 @@ def get_commit_from_github(tag_or_branch):
 def get_digest_from_s3(directory):
   # downloads the image-digest.txt from a directory in S3
   base_url = "https://gui.dockstore.org"
-  digest_url = "{}/{}/image-digest.txt".format(base_url, directory.replace("/","_"))
+  digest_url = "{}/{}/image-digest.txt".format(base_url, directory)
   response = requests.get(digest_url)
   if (response.status_code != 200):
     print("Expected a file at {}".format(digest_url))

--- a/scripts/webservice-image-digest.py
+++ b/scripts/webservice-image-digest.py
@@ -58,9 +58,10 @@ def get_commit_from_github(tag_or_branch):
 def get_digest_from_s3(directory):
   # downloads the image-digest.txt from a directory in S3
   base_url = "https://gui.dockstore.org"
-  response = requests.get("{}/{}/image-digest.txt".format(base_url, directory))
+  digest_url = "{}/{}/image-digest.txt".format(base_url, directory.replace("/","_"))
+  response = requests.get(digest_url)
   if (response.status_code != 200):
-    print("Expected a file at {}".format("{}/{}/image-digest.txt".format(base_url, directory)))
+    print("Expected a file at {}".format(digest_url))
     print("The image-digest.txt was not found in S3, did the build succeed?")
     exit(1)
   # There is a newline at the end of the file we rstrip
@@ -70,7 +71,7 @@ if __name__ == "__main__":
   # slashes are replaced with _ in docker image tags
   # check to see if input includes a dash followed by 7 chars
   parsed = args.tag.split('-')
-  if len(parsed) == 2 and len(parsed[1]) == 7 and all(c in string.hexdigits for c in parsed[1]):
+  if len(parsed) >= 2 and len(parsed[-1]) == 7 and all(c in string.hexdigits for c in parsed[-1]):
     directory = args.tag
   else:
     commit = get_commit_from_github(args.tag)

--- a/scripts/webservice-image-digest.py
+++ b/scripts/webservice-image-digest.py
@@ -58,7 +58,7 @@ def get_commit_from_github(tag_or_branch):
 def get_digest_from_s3(directory):
   # downloads the image-digest.txt from a directory in S3
   base_url = "https://gui.dockstore.org"
-  digest_url = "{}/{}/image-digest.txt".format(base_url, directory)
+  digest_url = "{}/{}/image-digest.txt".format(base_url, directory.replace("/", "_"))
   response = requests.get(digest_url)
   if (response.status_code != 200):
     print("Expected a file at {}".format(digest_url))


### PR DESCRIPTION
**Description**
This PR removes the code that implemented/facilitated the dynamic Galaxy plugin download/install during the deploy. Per the companion PR (https://github.com/dockstore/dockstore/pull/5208), the galaxy plugin will now be included in the webservice image.

Also, fixes a bug in `scripts/webservice-image-digest.py` which caused the deploy to fail if the webservice tag contained slashes or dashes.

**Review Instructions**
Confirm that the deploy succeeds.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4880

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
