### PR TITLE
Add metrics bucket name config

### DIFF
--- a/dockstore_launcher_config/compose.config
+++ b/dockstore_launcher_config/compose.config
@@ -39,6 +39,7 @@
 "GOOGLE_CLIENT_SECRET":"potato",
 "LOGSTASH":false,
 "LOGSTASH_HOST":"replaceme",
+"METRICS_BUCKET_NAME":"replaceme",
 "NEXTFLOW_PARSING_LAMBDA_VERSION":"n/a",
 "ORCID_CLIENT_ID":"replaceme",
 "ORCID_CLIENT_SECRET":"replaceme",

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -55,6 +55,8 @@ externalGoogleClientIdPrefixes:
 samconfiguration:
   basepath: {{ SAM_PATH }}
 
+metricsConfig:
+  s3BucketName: {{ METRICS_BUCKET_NAME }}
 
 # the following values describe where the webservice is being run (and on what port and using what scheme) to configure swagger
 externalConfig:


### PR DESCRIPTION
**Description**
Adds the metrics bucket name to the config file. 

Note that we don't need to create a `METRICS_BUCKET_NAME` key in Secrets Manager in each environment because the bucket name is imported into the Dockstore stack, which is then passed to the `init_bootstrap` script. More details in https://github.com/dockstore/dockstore-deploy/pull/661

Related PRs:
- https://github.com/dockstore/dockstore/pull/5357
- https://github.com/dockstore/dockstore-deploy/pull/661

**Review Instructions**
Verify that the Dockstore deploy succeeded

**Issue**
[SEAB-5062](https://ucsc-cgl.atlassian.net/browse/SEAB-5062)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.


[SEAB-5062]: https://ucsc-cgl.atlassian.net/browse/SEAB-5062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ