### PR TITLE
updates

### DIFF
--- a/DEV-README.md
+++ b/DEV-README.md
@@ -11,7 +11,7 @@ There are 3 different sets of metric logs being sent to logstash's elasticsearch
 
 ## Apache HTTP Logs
 
-Currently, install\_bootstrap and docker-compose handles all necessary configuration
+Currently, install\_bootstrap and docker compose handles all necessary configuration
 
 <!-- Long term, will likely move to AWS RDS, making postgres setup simpler
 ## Postgres

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Note that database migration is run once during the startup process and is contr
 
 ## Logging Usage
 
-If using with logstash in a container (for development), use `-f docker-compose.yml -f docker-compose.dev.yml` flags after each `docker-compose` command to merge docker-compose files (e.g. `docker-compose -f docker-compse.yml -f docker-compose.dev.yml build`) 
+If using with logstash in a container (for development), use `-f docker-compose.yml -f docker-compose.dev.yml` flags after each `docker compose` command to merge docker-compose files (e.g. `docker compose -f docker-compse.yml -f docker-compose.dev.yml build`)
 
 For example to deploy just logging 
 
 ```
-docker-compose  -f docker-compose.dev.yml build
-nohup docker-compose -f docker-compose.dev.yml up --force-recreate --remove-orphans >/dev/null 2>&1 &
-docker-compose -f docker-compose.dev.yml down
-docker-compose -f docker-compose.dev.yml kill
+docker compose  -f docker-compose.dev.yml build
+nohup docker compose -f docker-compose.dev.yml up --force-recreate --remove-orphans >/dev/null 2>&1 &
+docker compose -f docker-compose.dev.yml down
+docker compose -f docker-compose.dev.yml kill
 ```
 
 ### Kibana Dashboard Setup ###
@@ -65,7 +65,7 @@ If you believe the scan is a false-positive, add the line glob to .gitallowed.
 
 ## Handy docker-compose commands:
     1. `install_bootstrap --script` will template and build everything using your previous answers (useful for quick iteration) 
-    2. `docker-compose down` will bring all containers down safely 
-    3. `nohup docker-compose up --force-recreate --remove-orphans >/dev/null 2>&1 &` will re-create all containers known to docker-compose and delete those volumes that no longer are associated with running containers
+    2. `docker compose down` will bring all containers down safely
+    3. `nohup docker compose up --force-recreate --remove-orphans >/dev/null 2>&1 &` will re-create all containers known to docker-compose and delete those volumes that no longer are associated with running containers
     4. `docker system prune` for cleaning out old containers and images
-    5. To watch the logs `docker-compose logs --follow` while debugging
+    5. To watch the logs `docker compose logs --follow` while debugging

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -7,5 +7,5 @@ set -o nounset
 # Restarts stack by running commands from /home/ubuntu/compose_setup
 
 cd /home/ubuntu/compose_setup
-docker-compose down
-nohup docker-compose up --force-recreate --remove-orphans >/dev/null 2>&1 &
+docker compose down
+nohup docker compose up --force-recreate --remove-orphans >/dev/null 2>&1 &

--- a/templates/postgres_backup.sh.template
+++ b/templates/postgres_backup.sh.template
@@ -8,7 +8,7 @@ s3_url_config_backup='s3://oicr.backups.dockstore/{{ DOMAIN_NAME }}/config/'`dat
 temp_dir=`mktemp -d`
 output_file=ds-webservice_{{ DOMAIN_NAME }}_`date +%Y-%m-%dT%H-%M-%S%z`.sql
 
-/usr/local/bin/docker-compose exec -T --user postgres postgres pg_dump --no-owner > $temp_dir/$output_file
+/usr/local/bin/docker compose exec -T --user postgres postgres pg_dump --no-owner > $temp_dir/$output_file
 
 aws s3 --region us-east-1 cp $temp_dir/$output_file $s3_url_db_backup/
 aws s3 --region us-east-1 cp /home/ubuntu/compose_setup/dockstore_launcher_config/compose.config $s3_url_config_backup/


### PR DESCRIPTION
**Description**
While deploy uses the code from this repo, my understanding is that the versions of Docker and docker compose are irrelevant except for local development (i.e. AWS manages Docker behind the scenes for us)

**Review Instructions**
qa.dockstore.org's backups continue functioning

**Issue**
https://github.com/dockstore/dockstore/issues/5415

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
