### PR TITLE
Update web.yml.template for dropwizard 3/4

### DIFF
--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -12,4 +12,4 @@ java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -142,8 +142,14 @@ database:
   logAbandonedConnections: true
   removeAbandonedTimeout: 5 minutes
 
-{{#LOGSTASH}}
 server:
+  applicationConnectors:
+    - type: custom-http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8001
+{{#LOGSTASH}}
   requestLog:
     type: classic
     timeZone: UTC

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -112,7 +112,7 @@ database:
   # any properties specific to your JDBC driver:
   properties:
     charSet: UTF-8
-    hibernate.dialect: org.hibernate.dialect.PostgreSQL10Dialect
+    hibernate.dialect: org.hibernate.dialect.PostgreSQLDialect
     # create database as needed, disable in production
     hibernate.hbm2ddl.auto: validate
     hibernate.jdbc.batch_size: 30


### PR DESCRIPTION
**Description**
Dropwizard 3 changes how URLs are validated,  so we need a bit of a workaround via a lightly customised application connector. Dropwizard 4 includes hibernate 6 which merges a number of postgres dialects together.
Also adds 1.15 database migration

**Review Instructions**
qa  Dockstore should just work for the latter, for the former will need to try paths that look like `tools/%23workflow%2Fgithub.com%2Fgaryluu%2FtestWorkflow/versions/master/plain-CWL/descriptor//Dockstore.cwl` with the double slash. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5514
https://github.com/dockstore/dockstore/issues/5479

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
