### PR TITLE
SEAB-6148: Replace line feeds with carriage returns in log entries

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -91,9 +91,8 @@ logging:
     - type: console
 # this the default dropwizard (logstash) logFormat for reference      
       #logFormat: "%-5p [%d{ISO8601,UTC}] %c: %m%n%rEx"
-# this is a logFormat that replaces new lines in messages with a → 
-# TODO: should do the same with exceptions, but I couldn't figure it out
-      logFormat: "%-5p [%d{ISO8601,UTC}] %c: %replace(%msg){'[\\n]','→'}%n%rEx"
+# this is a logFormat that replaces new lines with carriage returns
+      logFormat: "%-5p [%d{ISO8601,UTC}] %c: %replace(%m){'\n','\r'}%n%replace(%rEx){'\n','\r'}"
 
 
 database:


### PR DESCRIPTION
**Description**
This PR changes the `web.yml.template` so that the webservice logging system maps line feeds (`\n`) to carriage returns (`\r`) in the log entry body (message and exception fields).

The Cloudwatch agent - which takes the webservice output, breaks it into log entries, and ships it to Cloudwatch - ignores the carriage returns.  And Cloudwatch itself displays the carriage returns as line breaks.  Thus, this change preserves multiline log entries without needing the "multiline-pattern" agent feature.

As with the previous code, this PR forecloses the possibility of the log corruption attack which involves injecting a line feed + a simulated log entry, because the line feed is mapped to a carriage return.  The attempt still appears, but as just another line in the body of multiline entry, rather than as an entirely separate log entry.

In the template, above this change, is a special logging format for the `org.hibernate.engine.internal.StatisticalLoggingSessionEventListener` output.  I left it there for now, but does anyone know if it is doing something useful?

**Screenshots**
Before:
![image](https://github.com/dockstore/compose_setup/assets/88108675/94e6d0c0-2135-4383-b6c4-f2a15182ccde)

After:
![image](https://github.com/dockstore/compose_setup/assets/88108675/b52868df-440a-4454-81ad-c506e6ac5fa1)

**Review Instructions**
View the webservice cloudwatch logs and confirm that multiline log entries are appearing as single expandable cloudwatch messages.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6148

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
