### PR TITLE
SEAB-6148: Enable diagnostics in webservice config template

### DIFF
--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -90,6 +90,7 @@ logging:
       appenders:
         - type: console
           logFormat: "%-5p [%d{ISO8601,UTC}] %c\t %replace(%replace(%msg){'[\\n{};]',''}){'([A-Za-z]) ([A-Za-z])','$1_$2'}%n%rEx"
+    "io.dockstore.webservice.helpers.DiagnosticsHelper": DEBUG
   #logging for other dropwizard things
   appenders:
     - type: console

--- a/templates/web.yml.template
+++ b/templates/web.yml.template
@@ -58,6 +58,10 @@ samconfiguration:
 metricsConfig:
   s3BucketName: {{ METRICS_BUCKET_NAME }}
 
+diagnosticsConfig:
+  logRequests: true
+  logPeriodic: true
+
 # the following values describe where the webservice is being run (and on what port and using what scheme) to configure swagger
 externalConfig:
   basePath: /api/


### PR DESCRIPTION
**Description**
This PR enables webservice diagnostic log output.

**Review Instructions**
See https://github.com/dockstore/dockstore/pull/5821

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6148

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
