### PR TITLE
SEAB-4998: Add read-only db password to compose.config

### DIFF
--- a/dockstore_launcher_config/compose.config
+++ b/dockstore_launcher_config/compose.config
@@ -54,6 +54,7 @@
 "PRODUCTION":false,
 "QUAY_CLIENT_ID":"foobared",
 "QUAY_CLIENT_SECRET":"foobared",
+"READONLY_DBPASSWORD":"replaceme",
 "SAM_PATH":"replaceme",
 "SLACK_URL":"replaeceme",
 "TAG_MANAGER_ID":"foobar",


### PR DESCRIPTION
**Description**
This PR adds a read-only password field to compose.config for the new `readonly` user.


**Review Instructions**
See https://github.com/dockstore/dockstore-deploy/pull/800

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-4998

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
