### PR TITLE
SEAB-6978: Add 1.17.0 to list of migrations

### DIFF
--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -12,4 +12,4 @@ java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0


### PR DESCRIPTION
**Description**
Add 1.17.0 to list of migrations per this comment https://github.com/dockstore/dockstore/pull/6089#pullrequestreview-2743484020

Long term, one wonders if we could somehow use the embedded list of migrations (https://github.com/dockstore/dockstore/blob/fbcba80140b9d13d3ec251283ecc823373ec0f3b/dockstore-integration-testing/src/test/java/io/dockstore/common/CommonTestUtilities.java#L88) to eliminate the need to change this on every release.  Maybe the webservice could spit them out if invoked the right way.  Such a change would allow me to simplify some of my db loading scripts, too.

**Review Instructions**
Confirm that qa deploys correctly.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6978

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
