### PR TITLE
SEAB-7194: Add 1.18.0 database migration

### DIFF
--- a/templates/init_migration.sh.template
+++ b/templates/init_migration.sh.template
@@ -12,4 +12,4 @@ java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD
 # this particular migration needs to run as postgres because only postgres can surrender ownership
 java -Ddw.database.user=postgres -Ddw.database.password="{{{ POSTGRES_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.7.0.relinquish
 # future migrations will start here and should be run as dockstore
-java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0
+java -Ddw.database.user=dockstore -Ddw.database.password="{{{ DOCKSTORE_DBPASSWORD }}}" -jar /home/dockstore-webservice-*.jar db migrate web.yml --include 1.8.0,1.9.0,1.10.0,1.11.0,1.12.0,1.13.0,1.14.0,1.15.0,1.16.0,1.17.0,1.18.0


### PR DESCRIPTION
**Description**
When I added the 1.18.0 migration to the webservice for a recent ticket, I forgot to update compose_setup, causing subsequent deploys to fail.  Fixed within.

**Review Instructions**
Confirm that the qa deploy succeeds.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7194

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
